### PR TITLE
Fall back to request URI if operationId not defined

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -38,7 +38,7 @@ class Middleware
 
         $response = $next($request);
 
-        if ($invalid = $this->validateResponse($operation, $response)) {
+        if ($invalid = $this->validateResponse($request->route()->uri(), $operation, $response)) {
             return $invalid;
         }
 
@@ -67,10 +67,10 @@ class Middleware
         }
     }
 
-    protected function validateResponse($operation, $response)
+    protected function validateResponse(string $uri, $operation, $response)
     {
         try {
-            ResponseValidator::validate($response, $operation);
+            ResponseValidator::validate($uri, $response, $operation);
         } catch (QueryException $exception) {
             throw $exception;
         } catch (UnresolvableReferenceException $exception) {

--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -9,19 +9,23 @@ use Spectator\Exceptions\ResponseValidationException;
 
 class ResponseValidator
 {
+    /** @var string request uri */
+    protected $uri;
+
     protected $response;
 
     protected $operation;
 
-    public function __construct($response, Operation $operation)
+    public function __construct(string $uri, $response, Operation $operation)
     {
+        $this->uri = $uri;
         $this->response = $response;
         $this->operation = $operation;
     }
 
-    public static function validate($response, Operation $operation)
+    public static function validate(string $uri, $response, Operation $operation)
     {
-        $instance = new self($response, $operation);
+        $instance = new self($uri, $response, $operation);
 
         $instance->handle();
     }
@@ -32,7 +36,7 @@ class ResponseValidator
         $body = $this->response->getContent();
         $responses = $this->operation->responses;
 
-        $shortHandler = class_basename($this->operation->operationId);
+        $shortHandler = class_basename($this->operation->operationId) ?: $this->uri;
 
         // Get matching response object based on status code.
         if ($responses[$this->response->getStatusCode()] !== null) {

--- a/tests/Fixtures/Test.v1.json
+++ b/tests/Fixtures/Test.v1.json
@@ -108,6 +108,28 @@
           }
         }
       }
+    },
+    "/path-without-operationId": {
+      "get": {
+        "summary": "Get route without operationId",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "int": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -64,4 +64,20 @@ class ResponseValidatorTest extends TestCase
             ->assertInvalidResponse(400)
             ->assertValidationMessage('get-users does not match the spec: [ format: {"type":"string","format":"email"} ]');
     }
+
+    public function test_fallback_to_request_uri_if_operationId_not_given()
+    {
+        Spectator::using('Test.v1.json');
+
+        Route::get('/path-without-operationId', function () {
+            return [
+                'int' => 'not an int'
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/path-without-operationId')
+            ->assertValidRequest()
+            ->assertInvalidResponse(400)
+            ->assertValidationMessage('path-without-operationId does not match the spec: [ type: {"expected":"integer","used":"string"} ]');
+    }
 }


### PR DESCRIPTION
A crude proposal to provide more context information in case no `operationId` is set. Providing access to the full request object in the response validation would also be an option.


```diff
- does not match the spec: [ type: {\"expected\":\"string\",\"used\":\"null\"} ]
+path-without-operationId does not match the spec: [ type: {\"expected\":\"string\",\"used\":\"null\"} ]
```