### PR TITLE
Include offending data pointer in response validation error

### DIFF
--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -71,7 +71,8 @@ class ResponseValidator
             if (!$result->isValid()) {
                 $error = $result->getFirstError();
                 $args = json_encode($error->keywordArgs());
-                throw ResponseValidationException::withError("{$shortHandler} does not match the spec: [ {$error->keyword()}: {$args} ]", $result->getErrors());
+                $dataPointer = implode('.', $error->dataPointer());
+                throw ResponseValidationException::withError("{$shortHandler} json response field {$dataPointer} does not match the spec: [ {$error->keyword()}: {$args} ]", $result->getErrors());
             }
         }
     }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -48,7 +48,7 @@ class ResponseValidatorTest extends TestCase
         $this->getJson('/users')
             ->assertValidRequest()
             ->assertInvalidResponse(400)
-            ->assertValidationMessage('get-users does not match the spec: [ type: {"expected":"number","used":"string"} ]');
+            ->assertValidationMessage('get-users json response field 0.id does not match the spec: [ type: {"expected":"number","used":"string"} ]');
 
         Route::get('/users', function () {
             return [
@@ -62,6 +62,6 @@ class ResponseValidatorTest extends TestCase
         $this->getJson('/users')
             ->assertValidRequest()
             ->assertInvalidResponse(400)
-            ->assertValidationMessage('get-users does not match the spec: [ format: {"type":"string","format":"email"} ]');
+            ->assertValidationMessage('get-users json response field 0.email does not match the spec: [ format: {"type":"string","format":"email"} ]');
     }
 }


### PR DESCRIPTION
Proposal to include the `dataPointer` of the offending field in json response.

```diff
-get-users does not match the spec: [ type: {"expected":"number","used":"string"} ]
+get-users json response field 0.email does not match the spec: [ format: {"type":"string","format":"email"} ]
```