### PR TITLE
Add support and testing for PHP8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,16 +14,17 @@ jobs:
       fail-fast: true
       matrix:
         laravel: [ 6.*, 7.*, 8.* ]
+        php: [ 7.2, 7.3, 7.4, 8.0 ]
         include:
           - laravel: 6.*
             testbench: 4.*
-            php: [ 7.2, 7.3, 7.4, 8.0 ]
           - laravel: 7.*
             testbench: 5.*
-            php: [ 7.2, 7.3, 7.4, 8.0 ]
           - laravel: 8.*
             testbench: 6.*
-            php: [ 7.3, 7.4, 8.0 ]
+        exclude:
+          - laravel: 8.*
+            php: 7.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,15 +13,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 7.2, 7.3, 7.4, 8.0 ]
         laravel: [ 6.*, 7.*, 8.* ]
         include:
           - laravel: 6.*
             testbench: 4.*
+            php: [ 7.2, 7.3, 7.4, 8.0 ]
           - laravel: 7.*
             testbench: 5.*
+            php: [ 7.2, 7.3, 7.4, 8.0 ]
           - laravel: 8.*
             testbench: 6.*
+            php: [ 7.3, 7.4, 8.0 ]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
@@ -36,12 +38,12 @@ jobs:
       uses: actions/cache@v2
       with:
         path: vendor
-        key: ${{ runner.os }}-node-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-${{ matrix.php }}--${{ matrix.laravel }}--node-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-node-
+          ${{ runner.os }}-${{ matrix.php }}--${{ matrix.laravel }}-node-
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, fileinfo, libxml, mbstring

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,13 +10,27 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ 7.2, 7.3, 7.4, 8.0 ]
+        laravel: [ 6.*, 7.*, 8.* ]
+        include:
+          - laravel: 6.*
+            testbench: 4.*
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 8.*
+            testbench: 6.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Validate composer.json and composer.lock
       run: composer validate
-      
+
     - name: Cache Composer packages
       id: composer-cache
       uses: actions/cache@v2
@@ -26,9 +40,18 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
 
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v1
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: dom, fileinfo, libxml, mbstring
+        coverage: none
+
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: |
+        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+        composer update --prefer-dist --no-progress --no-suggest
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "ext-json": "*",
     "cebe/php-openapi": "^1.4",
     "illuminate/support": "^6.0|^7.0|^8.0",
     "opis/json-schema": "^1.0"
   },
   "require-dev": {
-    "orchestra/testbench": "~3.0",
+    "orchestra/testbench": "^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^7.0|^8.0|^9.0"
   },
   "autoload": {

--- a/src/ResponseMixin.php
+++ b/src/ResponseMixin.php
@@ -13,7 +13,7 @@ class ResponseMixin
     public function assertValidRequest()
     {
         return function () {
-            $contents = $this->getContent() ? $contents = (array) $this->decodeResponseJson() : [];
+            $contents = $this->getContent() ? $contents = (array) $this->json() : [];
 
             PHPUnit::assertFalse(
                 in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
@@ -27,7 +27,7 @@ class ResponseMixin
     public function assertInvalidRequest()
     {
         return function () {
-            $contents = (array) $this->decodeResponseJson();
+            $contents = (array) $this->json();
 
             PHPUnit::assertTrue(
                 !in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
@@ -41,7 +41,7 @@ class ResponseMixin
     public function assertValidResponse()
     {
         return function ($status = null) {
-            $contents = $this->getContent() ? (array) $this->decodeResponseJson() : [];
+            $contents = $this->getContent() ? (array) $this->json() : [];
 
             PHPUnit::assertFalse(
                 in_array(Arr::get($contents, 'exception'), [ResponseValidationException::class, UnresolvableReferenceException::class]),
@@ -64,7 +64,7 @@ class ResponseMixin
     public function assertInvalidResponse()
     {
         return function ($status = null) {
-            $contents = (array) $this->decodeResponseJson();
+            $contents = (array) $this->json();
 
             PHPUnit::assertTrue(
                 in_array(Arr::get($contents, 'exception'), [ResponseValidationException::class, UnresolvableReferenceException::class]),


### PR DESCRIPTION
This PR adds php 8 in composer.json

Tests are now run on all supported php versions and for all supported laravel version

orchestra/testbench version was bumped with documented versions (https://github.com/orchestral/testbench)