### PR TITLE
Fix path_prefix to work with multi-segment urls

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -108,7 +108,7 @@ class Middleware
         $separator = '/';
 
         $parts = array_filter(array_map(function ($part) use ($separator) {
-            return str_replace($separator, '', $part);
+            return trim($part, $separator);
         }, [
             config('spectator.path_prefix'),
             $path,

--- a/tests/Fixtures/Test.v2.json
+++ b/tests/Fixtures/Test.v2.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Test.v1",
+    "title": "Test.v2",
     "version": "1.0"
   },
   "servers": [

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -86,7 +86,7 @@ class ResponseValidatorTest extends TestCase
     {
         Spectator::using('Test.v2.json');
 
-        Route::get('/v2/users', function () {
+        Route::get('/api/v2/users', function () {
             return [
                 [
                     'id' => 1,
@@ -96,14 +96,14 @@ class ResponseValidatorTest extends TestCase
             ];
         })->middleware(Middleware::class);
 
-        $this->getJson('/v2/users')
+        $this->getJson('/api/v2/users')
             ->assertValidRequest()
             ->assertValidResponse(422)
-            ->assertValidationMessage('Path [GET /v2/users] not found in spec.');
+            ->assertValidationMessage('Path [GET /api/v2/users] not found in spec.');
 
-        Config::set('spectator.path_prefix', 'v2');
+        Config::set('spectator.path_prefix', '/api/v2/');
 
-        $this->getJson('/v2/users')
+        $this->getJson('/api/v2/users')
             ->assertValidRequest()
             ->assertValidResponse(200);
     }


### PR DESCRIPTION
Allow `path_prefix` to contain slashes, e.g. `api/v2`.