### PR TITLE
Bugfix: Missing namespace for service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "SpectatorServiceProvider"
+        "Spectator\\SpectatorServiceProvider"
       ]
     }
   },


### PR DESCRIPTION
Version 0.6.3 included a rename of the service provider from `src/ServiceProvider.php` to `src/SpectatorServiceProvider.php` as can be seen here: https://github.com/hotmeteor/spectator/compare/v0.6.2...v0.6.3

This PR fixes the issue that the namespace `Spectator` was not added correctly to the `composer.json` file hence causing errors when installing in a Laravel app:

```sh
composer require hotmeteor/spectator --dev   

Using version ^0.6.3 for hotmeteor/spectator
./composer.json has been updated
Running composer update hotmeteor/spectator
Loading composer repositories with package information
Updating dependencies
Lock file operations: 4 installs, 0 updates, 0 removals
  - Locking cebe/php-openapi (1.4.2)
  - Locking hotmeteor/spectator (v0.6.3)
  - Locking justinrainbow/json-schema (5.2.10)
  - Locking opis/json-schema (1.0.19)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 4 installs, 0 updates, 0 removals
  - Installing opis/json-schema (1.0.19): Extracting archive
  - Installing justinrainbow/json-schema (5.2.10): Extracting archive
  - Installing cebe/php-openapi (1.4.2): Extracting archive
  - Installing hotmeteor/spectator (v0.6.3): Extracting archive
1 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package moontoast/math is abandoned, you should avoid using it. Use brick/math instead.
Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested.
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

In ProviderRepository.php line 208:
                                              
  Class 'SpectatorServiceProvider' not found  
                                              

Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```