### PR TITLE
fix/publish config issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require hotmeteor/spectator --dev
 Then, publish the config file of this package with this command:
 
 ```bash
-php artisan vendor:publish --provider="Spectator\ServiceProvider"
+php artisan vendor:publish --provider="Spectator\SpectatorServiceProvider"
 ```
 
 The config file will be published in `config/spectator.php`.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Spectator\\SpectatorServiceProvider"
+        "Spectator\\ServiceProvider"
       ]
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Spectator\\ServiceProvider"
+        "Spectator\\SpectatorServiceProvider"
       ]
     }
   },

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -13,9 +13,8 @@ class SpectatorServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->publishConfig();
-
-        if (App::runningUnitTests()) {
+        if (App::runningInConsole()) {
+            $this->publishConfig();
             $this->registerMiddleware();
             $this->decorateTestResponse();
         }

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -13,8 +13,9 @@ class SpectatorServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        $this->publishConfig();
+
         if (App::runningUnitTests()) {
-            $this->publishConfig();
             $this->registerMiddleware();
             $this->decorateTestResponse();
         }


### PR DESCRIPTION
This PR addresses two issues:

* The Service Provider name wasn't found when I run `php artisan vendor:publish --provider="Spectator\ServiceProvider" because the name in the composer.json is `"Spectator\SpectatorServiceProvider"`

* The config was not publishable on installation because it was in the `App::runningUnitTests()`, which breaks for Feature Tests and when running the `vendor:publish` command. 

This will fix #15. 