### PR TITLE
Issue/19 json oas compat

### DIFF
--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -4,6 +4,7 @@ namespace Spectator;
 
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Spectator\Exceptions\InvalidPathException;
 use Spectator\Exceptions\RequestValidationException;
 use Spectator\Exceptions\ResponseValidationException;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
@@ -16,7 +17,11 @@ class Assertions
             $contents = $this->getContent() ? $contents = (array) $this->json() : [];
 
             PHPUnit::assertFalse(
-                in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
+                in_array(Arr::get($contents, 'exception'), [
+                    RequestValidationException::class,
+                    UnresolvableReferenceException::class,
+                    InvalidPathException::class,
+                ]),
                 $this->decodeExceptionMessage($contents)
             );
 
@@ -30,7 +35,11 @@ class Assertions
             $contents = (array) $this->json();
 
             PHPUnit::assertTrue(
-                !in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
+                in_array(Arr::get($contents, 'exception'), [
+                    RequestValidationException::class,
+                    UnresolvableReferenceException::class,
+                    InvalidPathException::class,
+                ]),
                 $this->decodeExceptionMessage($contents)
             );
 

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -5,6 +5,7 @@ namespace Spectator;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Spectator\Exceptions\InvalidPathException;
+use Spectator\Exceptions\MissingSpecException;
 use Spectator\Exceptions\RequestValidationException;
 use Spectator\Exceptions\ResponseValidationException;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
@@ -18,9 +19,10 @@ class Assertions
 
             PHPUnit::assertFalse(
                 in_array(Arr::get($contents, 'exception'), [
+                    InvalidPathException::class,
+                    MissingSpecException::class,
                     RequestValidationException::class,
                     UnresolvableReferenceException::class,
-                    InvalidPathException::class,
                 ]),
                 $this->decodeExceptionMessage($contents)
             );
@@ -36,9 +38,10 @@ class Assertions
 
             PHPUnit::assertTrue(
                 in_array(Arr::get($contents, 'exception'), [
+                    InvalidPathException::class,
+                    MissingSpecException::class,
                     RequestValidationException::class,
                     UnresolvableReferenceException::class,
-                    InvalidPathException::class,
                 ]),
                 $this->decodeExceptionMessage($contents)
             );

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -32,14 +32,14 @@ class Middleware
 
         try {
             $response = $this->validate($request, $next);
+        } catch (InvalidPathException $exception) {
+            return $this->formatResponse($exception, 422);
         } catch (RequestValidationException $exception) {
             return $this->formatResponse($exception, 400);
         } catch (ResponseValidationException $exception) {
             return $this->formatResponse($exception, 400);
         } catch (InvalidMethodException $exception) {
             return $this->formatResponse($exception, 405);
-        } catch (InvalidPathException $exception) {
-            return $this->formatResponse($exception, 422);
         } catch (MissingSpecException $exception) {
             return $this->formatResponse($exception, 500);
         } catch (UnresolvableReferenceException $exception) {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -19,6 +19,8 @@ class Middleware
 {
     protected $spectator;
 
+    protected $version = '3.0';
+
     public function __construct(RequestFactory $spectator)
     {
         $this->spectator = $spectator;
@@ -73,7 +75,7 @@ class Middleware
 
         $response = $next($request);
 
-        ResponseValidator::validate($request_path, $response, $operation);
+        ResponseValidator::validate($request_path, $response, $operation, $this->version);
 
         $this->spectator->reset();
 
@@ -87,6 +89,8 @@ class Middleware
         }
 
         $openapi = $this->spectator->resolve();
+
+        $this->version = $openapi->openapi;
 
         foreach ($openapi->paths as $path => $pathItem) {
             if ($this->resolvePath($path) === $request_path) {

--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -2,14 +2,17 @@
 
 namespace Spectator\Validation;
 
+use Exception;
+use cebe\openapi\spec\Schema;
 use Opis\JsonSchema\Validator;
+use cebe\openapi\spec\Response;
 use cebe\openapi\spec\Operation;
+use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Exception\SchemaKeywordException;
 use Spectator\Exceptions\ResponseValidationException;
 
 class ResponseValidator
 {
-    /** @var string request uri */
     protected $uri;
 
     protected $response;
@@ -30,57 +33,119 @@ class ResponseValidator
         $instance->handle();
     }
 
+    /**
+     * @throws ResponseValidationException
+     */
     protected function handle()
     {
-        $contentType = $this->response->headers->get('Content-Type');
-        $body = $this->response->getContent();
-        $responses = $this->operation->responses;
-
-        $shortHandler = class_basename($this->operation->operationId) ?: $this->uri;
-
-        // Get matching response object based on status code.
-        if ($responses[$this->response->getStatusCode()] !== null) {
-            $responseObject = $responses[$this->response->getStatusCode()];
-        } elseif ($responses['default'] !== null) {
-            $responseObject = $responses['default'];
-        } else {
-            throw new ResponseValidationException("No response object matching returned status code [{$this->response->getStatusCode()}].");
-        }
+        $responseObject = $this->response();
 
         if ($responseObject->content) {
-            if (!array_key_exists($contentType, $responseObject->content)) {
-                throw new ResponseValidationException('Response did not match any specified media type.');
-            }
+            $this->parseResponse($responseObject);
+        }
+    }
 
-            $schema = $responseObject->content[$contentType]->schema;
+    /**
+     * @throws ResponseValidationException
+     */
+    protected function parseResponse(Response $response)
+    {
+        $contentType = $this->contentType();
 
-            if ($schema->type === 'object' || $schema->type === 'array') {
-                if (in_array($contentType, ['application/json', 'application/vnd.api+json'])) {
-                    $body = json_decode($body);
-                } else {
-                    throw new ResponseValidationException("Unable to map [{$contentType}] to schema type [object].");
-                }
-            }
+        if (!array_key_exists($contentType, $response->content)) {
+            throw new ResponseValidationException('Response did not match any specified media type.');
+        }
 
-            $validator = $this->validator();
-            $result = null;
+        $schema = $response->content[$contentType]->schema;
 
-            try {
-                $result = $validator->dataValidation($body, $schema->getSerializableData(), -1);
-            } catch (SchemaKeywordException $exception) {
-                throw ResponseValidationException::withError("{$shortHandler} has invalid schema: [ {$exception->getMessage()} ]");
-            } catch (\Exception $exception) {
-                throw ResponseValidationException::withError($exception->getMessage());
-            }
+        $this->validateResponse(
+            $schema, $this->body($contentType, $schema->type)
+        );
+    }
 
-            if (optional($result)->isValid() === false) {
-                $error = $result->getFirstError();
-                $args = json_encode($error->keywordArgs());
-                $dataPointer = implode('.', $error->dataPointer());
+    /**
+     * @param $body
+     *
+     * @throws ResponseValidationException
+     */
+    protected function validateResponse(Schema $schema, $body)
+    {
+        $result = null;
+        $validator = $this->validator();
+        $shortHandler = $this->shortHandler();
 
-                throw ResponseValidationException::withError("{$shortHandler} json response field {$dataPointer} does not match the spec: [ {$error->keyword()}: {$args} ]", $result->getErrors());
+        try {
+            $result = $validator->dataValidation($body, $schema->getSerializableData(), -1);
+        } catch (SchemaKeywordException $exception) {
+            throw ResponseValidationException::withError("{$shortHandler} has invalid schema: [ {$exception->getMessage()} ]");
+        } catch (Exception $exception) {
+            throw ResponseValidationException::withError($exception->getMessage());
+        }
+
+        if ($result instanceof ValidationResult && $result->isValid() === false) {
+            $error = $result->getFirstError();
+            $args = json_encode($error->keywordArgs());
+            $dataPointer = implode('.', $error->dataPointer());
+
+            throw ResponseValidationException::withError("{$shortHandler} json response field {$dataPointer} does not match the spec: [ {$error->keyword()}: {$args} ]", $result->getErrors());
+        }
+    }
+
+    /**
+     * @throws ResponseValidationException
+     */
+    protected function response(): Response
+    {
+        $responses = $this->operation->responses;
+
+        if ($responses[$this->response->getStatusCode()] !== null) {
+            return $responses[$this->response->getStatusCode()];
+        }
+
+        if ($responses['default'] !== null) {
+            return $responses['default'];
+        }
+
+        throw new ResponseValidationException("No response object matching returned status code [{$this->response->getStatusCode()}].");
+    }
+
+    /**
+     * @return string
+     */
+    protected function contentType()
+    {
+        return $this->response->headers->get('Content-Type');
+    }
+
+    /**
+     * @param $contentType
+     * @param $schemaType
+     *
+     * @return mixed
+     *
+     * @throws ResponseValidationException
+     */
+    protected function body($contentType, $schemaType)
+    {
+        $body = $this->response->getContent();
+
+        if (in_array($schemaType, ['object', 'array'], true)) {
+            if (in_array($contentType, ['application/json', 'application/vnd.api+json'])) {
+                return json_decode($body);
+            } else {
+                throw new ResponseValidationException("Unable to map [{$contentType}] to schema type [object].");
             }
         }
+
+        return $body;
+    }
+
+    /**
+     * @return string
+     */
+    protected function shortHandler()
+    {
+        return class_basename($this->operation->operationId) ?: $this->uri;
     }
 
     protected function validator(): Validator

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Spectator\Tests\Fixtures;
+namespace Spectator\Tests;
 
 use Spectator\Spectator;
 use Spectator\Middleware;
-use Spectator\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 use Spectator\SpectatorServiceProvider;
 
@@ -32,6 +31,7 @@ class AssertionsTest extends TestCase
         })->middleware(Middleware::class);
 
         $this->getJson('/invalid')
-            ->assertInvalidRequest();
+            ->assertInvalidRequest()
+            ->assertValidationMessage('Path [GET /invalid] not found in spec.');
     }
 }

--- a/tests/Fixtures/AssertionsTest.php
+++ b/tests/Fixtures/AssertionsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spectator\Tests\Fixtures;
+
+use Spectator\Spectator;
+use Spectator\Middleware;
+use Spectator\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use Spectator\SpectatorServiceProvider;
+
+class AssertionsTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->register(SpectatorServiceProvider::class);
+
+        Spectator::using('Test.v1.json');
+    }
+
+    public function test_asserts_invalid_path()
+    {
+        Route::get('/invalid', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/invalid')
+            ->assertInvalidRequest();
+    }
+}

--- a/tests/Fixtures/Nullable.3.0.json
+++ b/tests/Fixtures/Nullable.3.0.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Nullable.3.0",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/users/{user}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "user",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "Get single user",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "first_name": {
+                      "type": "string",
+                      "example": "Joe"
+                    },
+                    "last_name": {
+                      "type": "string",
+                      "example": "Bloggs"
+                    },
+                    "favourite_colour": {
+                      "type": "string",
+                      "example": "Red",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-users-user"
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/tests/Fixtures/Nullable.3.1.json
+++ b/tests/Fixtures/Nullable.3.1.json
@@ -1,7 +1,7 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
-    "title": "Nullable.3.0",
+    "title": "Nullable.3.1",
     "version": "1.0"
   },
   "servers": [
@@ -41,9 +41,8 @@
                       "example": "Bloggs"
                     },
                     "email": {
-                      "type": "string",
-                      "example": "test@test.com",
-                      "nullable": true
+                      "type": ["string", "null"],
+                      "example": "test@test.com"
                     }
                   }
                 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -97,8 +97,7 @@ class ResponseValidatorTest extends TestCase
         })->middleware(Middleware::class);
 
         $this->getJson('/api/v2/users')
-            ->assertValidRequest()
-            ->assertValidResponse(422)
+            ->assertInvalidRequest()
             ->assertValidationMessage('Path [GET /api/v2/users] not found in spec.');
 
         Config::set('spectator.path_prefix', '/api/v2/');
@@ -106,5 +105,23 @@ class ResponseValidatorTest extends TestCase
         $this->getJson('/api/v2/users')
             ->assertValidRequest()
             ->assertValidResponse(200);
+    }
+
+    public function test_handle_nullable_in_oa3dot0()
+    {
+        Spectator::using('Nullable.3.0.json');
+
+        Route::get('/api/v1/users/1', function () {
+            return [
+                [
+                    'first_name' => 'Joe',
+                    'last_name' => 'Bloggs',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/api/v1/users/1')
+            ->assertValidRequest()
+            ->assertValidResponse();
     }
 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -10,6 +10,12 @@ use Spectator\SpectatorServiceProvider;
 
 class ResponseValidatorTest extends TestCase
 {
+    const NULLABLE_MISSING = 0;
+    const NULLABLE_EMPTY = 1;
+    const NULLABLE_VALID = 2;
+    const NULLABLE_INVALID = 3;
+    const NULLABLE_NULL = 4;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -107,21 +113,122 @@ class ResponseValidatorTest extends TestCase
             ->assertValidResponse(200);
     }
 
-    public function test_handle_nullable_in_oa3dot0()
-    {
-        Spectator::using('Nullable.3.0.json');
+    /**
+     * @dataProvider nullableProvider
+     */
+    public function test_handle_nullables(
+        $version,
+        $state,
+        $is_valid
+    ) {
+        Spectator::using("Nullable.{$version}.json");
 
-        Route::get('/api/v1/users/1', function () {
-            return [
-                [
-                    'first_name' => 'Joe',
-                    'last_name' => 'Bloggs',
-                ],
+        Route::get('/users/{user}', function () use ($state) {
+            $return = [
+                'first_name' => 'Joe',
+                'last_name' => 'Bloggs',
             ];
+
+            if ($state === self::NULLABLE_EMPTY) {
+                $return['email'] = '';
+            }
+
+            if ($state === self::NULLABLE_VALID) {
+                $return['email'] = 'test@test.com';
+            }
+
+            if ($state === self::NULLABLE_INVALID) {
+                $return['email'] = [1, 2, 3];
+            }
+
+            if ($state === self::NULLABLE_NULL) {
+                $return['email'] = null;
+            }
+
+            return $return;
         })->middleware(Middleware::class);
 
-        $this->getJson('/api/v1/users/1')
-            ->assertValidRequest()
-            ->assertValidResponse();
+        if ($is_valid) {
+            $this->getJson('/users/1')
+                ->assertValidRequest()
+                ->assertValidResponse();
+        } else {
+            $this->getJson('/users/1')
+                ->assertValidRequest()
+                ->assertInvalidResponse();
+        }
+    }
+
+    public function nullableProvider()
+    {
+        $validResponse = true;
+        $invalidResponse = false;
+
+        $v30 = '3.0';
+        $v31 = '3.1';
+
+        return [
+            // OA 3.0.0
+            '3.0, missing' => [
+                $v30,
+                self::NULLABLE_MISSING,
+                $validResponse,
+            ],
+
+            '3.0, empty' => [
+                $v30,
+                self::NULLABLE_EMPTY,
+                $validResponse,
+            ],
+
+            '3.0, null' => [
+                $v30,
+                self::NULLABLE_NULL,
+                $validResponse,
+            ],
+
+            '3.0, valid' => [
+                $v30,
+                self::NULLABLE_VALID,
+                $validResponse,
+            ],
+
+            '3.0, invalid' => [
+                $v30,
+                self::NULLABLE_INVALID,
+                $invalidResponse,
+            ],
+
+            // OA 3.1.0
+            '3.1, missing' => [
+                $v31,
+                self::NULLABLE_MISSING,
+                $validResponse,
+            ],
+
+            '3.1, empty' => [
+                $v31,
+                self::NULLABLE_EMPTY,
+                $validResponse,
+            ],
+
+            '3.1, null' => [
+                $v31,
+                self::NULLABLE_NULL,
+                $validResponse,
+            ],
+
+            '3.1, valid' => [
+                $v31,
+                self::NULLABLE_VALID,
+                $validResponse,
+            ],
+
+            '3.1, invalid' => [
+                $v31,
+                self::NULLABLE_INVALID,
+                $invalidResponse,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### Changes

Adds support for 3.0.x `nullable` property by forcing an array of types that includes `'null'`

Doesn't apply to 3.1.x specs since `nullable` will be deprecated

See https://apisyouwonthate.com/blog/openapi-v31-and-json-schema-2019-09

Resolves https://github.com/hotmeteor/spectator/issues/19

### Fixes

- Fixes bad detection and reporting of invalid paths. Invalid paths will throw a correct request error now.
- Fixes bad detection and reporting of missing specs. Missing specs will throw a correct request error now.
- Refactors `ResponseValidator` to be more readable