### PR TITLE
Better error reporting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "opis/json-schema": "^1.0"
   },
   "require-dev": {
+    "nunomaduro/collision": "^5.1",
     "orchestra/testbench": "^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^7.0|^8.0|^9.0"
   },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         forceCoversAnnotation="false"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
+>
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">src</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
 >
   <coverage processUncoveredFiles="true">
     <include>

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -2,6 +2,7 @@
 
 namespace Spectator;
 
+use Closure;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Spectator\Exceptions\RequestValidationException;
@@ -14,39 +15,41 @@ class Assertions
     public function assertValidRequest()
     {
         return function () {
-            $contents = $this->getContent() ? $contents = (array) $this->json() : [];
+            return $this->runAssertion(function () {
+                $contents = $this->getContent() ? $contents = (array) $this->json() : [];
 
-            PHPUnit::assertFalse(
-                in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
-                $this->decodeExceptionMessage($contents)
-            );
+                PHPUnit::assertFalse(
+                    in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
+                    $this->decodeExceptionMessage($contents)
+                );
 
-            return $this;
+                return $this;
+            });
         };
     }
 
     public function assertInvalidRequest()
     {
         return function () {
-            $contents = (array) $this->json();
+            return $this->runAssertion(function () {
+                $contents = (array) $this->json();
 
-            PHPUnit::assertTrue(
-                !in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
-                $this->decodeExceptionMessage($contents)
-            );
+                PHPUnit::assertTrue(
+                    !in_array(Arr::get($contents, 'exception'), [RequestValidationException::class, UnresolvableReferenceException::class]),
+                    $this->decodeExceptionMessage($contents)
+                );
 
-            return $this;
+                return $this;
+            });
         };
     }
 
     public function assertValidResponse()
     {
         return function ($status = null) {
-            $original = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2];
+            return $this->runAssertion(function () use ($status) {
+                $contents = $this->getContent() ? (array) $this->json() : [];
 
-            $contents = $this->getContent() ? (array) $this->json() : [];
-
-            try {
                 PHPUnit::assertFalse(
                     in_array(Arr::get($contents, 'exception'), [ResponseValidationException::class, UnresolvableReferenceException::class]),
                     $this->decodeExceptionMessage($contents)
@@ -60,65 +63,63 @@ class Assertions
                         "Expected status code {$status} but received {$actual}."
                     );
                 }
-            } catch (\Exception $exception) {
-                throw new \ErrorException(
-                    $exception->getMessage(),
-                    $exception->getCode(),
-                    $severity = 1,
-                    $original['file'],
-                    $original['line']
-                );
-            }
 
-            return $this;
+                return $this;
+            });
         };
     }
 
     public function assertInvalidResponse()
     {
         return function ($status = null) {
-            $contents = (array) $this->json();
-
-            PHPUnit::assertTrue(
-                in_array(Arr::get($contents, 'exception'), [ResponseValidationException::class, UnresolvableReferenceException::class]),
-                $this->decodeExceptionMessage($contents)
-            );
-
-            if ($status) {
-                $actual = $this->getStatusCode();
+            return $this->runAssertion(function () use ($status) {
+                $contents = (array) $this->json();
 
                 PHPUnit::assertTrue(
-                    $actual === $status,
-                    "Expected status code {$status} but received {$actual}."
+                    in_array(Arr::get($contents, 'exception'), [ResponseValidationException::class, UnresolvableReferenceException::class]),
+                    $this->decodeExceptionMessage($contents)
                 );
-            }
 
-            return $this;
+                if ($status) {
+                    $actual = $this->getStatusCode();
+
+                    PHPUnit::assertTrue(
+                        $actual === $status,
+                        "Expected status code {$status} but received {$actual}."
+                    );
+                }
+
+                return $this;
+            });
         };
     }
 
     public function assertValidationMessage()
     {
         return function ($expected) {
-            $actual = $this->getData()->message;
+            return $this->runAssertion(function () use ($expected) {
+                $actual = $this->getData()->message;
 
-            PHPUnit::assertSame(
-                $expected, $actual,
-                'The expected error did not match the actual error.'
-            );
+                PHPUnit::assertSame(
+                    $expected, $actual,
+                    'The expected error did not match the actual error.'
+                );
 
-            return $this;
+                return $this;
+            });
         };
     }
 
     public function assertErrorsContain()
     {
         return function ($errors) {
-            self::assertJson([
-                'errors' => Arr::wrap($errors),
-            ]);
+            return $this->runAssertion(function () use ($errors) {
+                self::assertJson([
+                    'errors' => Arr::wrap($errors),
+                ]);
 
-            return $this;
+                return $this;
+            });
         };
     }
 
@@ -126,6 +127,19 @@ class Assertions
     {
         return function ($contents) {
             return Arr::get($contents, 'message', '');
+        };
+    }
+
+    protected function runAssertion()
+    {
+        return function (Closure $closure) {
+            $original = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 6)[5];
+
+            try {
+                return $closure();
+            } catch (\Exception $exception) {
+                throw new \ErrorException($exception->getMessage(), $exception->getCode(), E_WARNING, $original['file'], $original['line']);
+            }
         };
     }
 }

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -18,8 +18,13 @@ class AssertionsTest extends TestCase
         Spectator::using('Test.v1.json');
     }
 
-    public function testShowsProperStacktrace()
+    public function testExceptionPointsToMixinMethod()
     {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('No response object matching returned status code [500].
+Failed asserting that true is false.');
+
         Route::get('/users', function () {
             throw new \Exception('Explosion');
         })->middleware(Middleware::class);

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spectator\Tests;
+
+use Spectator\Spectator;
+use Spectator\Middleware;
+use Illuminate\Support\Facades\Route;
+use Spectator\SpectatorServiceProvider;
+
+class AssertionsTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->register(SpectatorServiceProvider::class);
+
+        Spectator::using('Test.v1.json');
+    }
+
+    public function testShowsProperStacktrace()
+    {
+        Route::get('/users', function () {
+            throw new \Exception('Explosion');
+        })->middleware(Middleware::class);
+
+        $this->getJson('/users')
+            ->assertValidRequest()
+            ->assertValidResponse(200);
+    }
+}


### PR DESCRIPTION
This updates the way that failing tests display the line where it's failing. Before, it would refer to the line in the `Assertions` class, which isn't very helpful. Now it will point to the line in your actual test class.

### Before:
<img width="1466" alt="Screen Shot 2020-12-17 at 7 50 22 AM" src="https://user-images.githubusercontent.com/378585/102504093-045ca180-4046-11eb-91e1-207b53be114a.png">

### After:
<img width="1466" alt="Screen Shot 2020-12-17 at 7 50 49 AM" src="https://user-images.githubusercontent.com/378585/102504179-1fc7ac80-4046-11eb-801c-a8081eb74cca.png">

