### PR TITLE
Add support for object properties that have nullable properties

### DIFF
--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -170,15 +170,29 @@ class ResponseValidator
 
         $v30 = Str::startsWith($this->version, '3.0');
 
-        foreach ($clone->properties as $key => $attributes) {
-            if ($v30 && isset($attributes->nullable)) {
+        if ($v30) {
+            $clone->properties = $this->wrapAttributesToArray($clone->properties);
+        }
+
+
+        return $clone;
+    }
+
+    protected function wrapAttributesToArray($properties)
+    {
+        foreach ($properties as $key => $attributes) {
+            if (isset($attributes->nullable)) {
                 $type = Arr::wrap($attributes->type);
                 $type[] = 'null';
                 $attributes->type = array_unique($type);
                 unset($attributes->nullable);
             }
+
+            if ($attributes->type === 'object') {
+                $attributes->properties = $this->wrapAttributesToArray($attributes->properties);
+            }
         }
 
-        return $clone;
+        return $properties;
     }
 }

--- a/tests/Fixtures/Nullable.3.0.json
+++ b/tests/Fixtures/Nullable.3.0.json
@@ -44,6 +44,26 @@
                       "type": "string",
                       "example": "test@test.com",
                       "nullable": true
+                    },
+                    "settings": {
+                      "type": "object",
+                      "properties": {
+                        "last_updated_at": {
+                          "type": "string",
+                          "example": "2020-10-10",
+                          "nullable": true
+                        },
+                        "notifications": {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "type": "string",
+                              "example": "daily",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/tests/Fixtures/Nullable.3.1.json
+++ b/tests/Fixtures/Nullable.3.1.json
@@ -43,6 +43,24 @@
                     "email": {
                       "type": ["string", "null"],
                       "example": "test@test.com"
+                    },
+                    "settings": {
+                      "type": "object",
+                      "properties": {
+                        "last_updated_at": {
+                          "type": ["string", "null"],
+                          "example": "2020-10-10"
+                        },
+                        "notifications": {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "type": ["string", "null"],
+                              "example": "daily"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -2,10 +2,10 @@
 
 namespace Spectator\Tests;
 
-use Spectator\Spectator;
-use Spectator\Middleware;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Spectator\Middleware;
+use Spectator\Spectator;
 use Spectator\SpectatorServiceProvider;
 
 class ResponseValidatorTest extends TestCase
@@ -131,6 +131,8 @@ class ResponseValidatorTest extends TestCase
 
             if ($state === self::NULLABLE_EMPTY) {
                 $return['email'] = '';
+                $return['settings']['last_updated_at'] = '';
+                $return['settings']['notifications']['email'] = '';
             }
 
             if ($state === self::NULLABLE_VALID) {
@@ -139,10 +141,14 @@ class ResponseValidatorTest extends TestCase
 
             if ($state === self::NULLABLE_INVALID) {
                 $return['email'] = [1, 2, 3];
+                $return['settings']['last_updated_at'] = [1, 2, 3];
+                $return['settings']['notifications']['email'] = [1, 2, 3];
             }
 
             if ($state === self::NULLABLE_NULL) {
                 $return['email'] = null;
+                $return['settings']['last_updated_at'] = null;
+                $return['settings']['notifications']['email'] = null;
             }
 
             return $return;


### PR DESCRIPTION
I tried this package out in a test suite with OpenAPI v3.0.x that has a lot of responses with objects that have nullable properties.
I discovered that the schema is not updated to the JSON-schema array format for those properties so the assertions are failing.

This PR adds support to validate a schema like:

```
"schema": {
  "type": "object",
  "properties": {
    "key": {
      "nested_key": {
        "type": "object",
        "properties": {
          "nullable_key": {
          "nullable": true,  <--- This was not checked before
          "type": "string"
        }
      }
    }  
  }
}
```