### PR TITLE
Add support for schema that has an array of objects with nullable properties

### DIFF
--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -188,13 +188,14 @@ class ResponseValidator
                 unset($attributes->nullable);
             }
 
-            if ($attributes->type === 'object') {
+            if ($attributes->type === 'object' && isset($attributes->properties)) {
                 $attributes->properties = $this->wrapAttributesToArray($attributes->properties);
             }
 
             if (
                 $attributes->type === 'array'
                 && isset($attributes->items)
+                && isset($attributes->items->properties)
                 && $attributes->items->type === 'object'
             ) {
                 $attributes->items->properties = $this->wrapAttributesToArray($attributes->items->properties);

--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -191,6 +191,14 @@ class ResponseValidator
             if ($attributes->type === 'object') {
                 $attributes->properties = $this->wrapAttributesToArray($attributes->properties);
             }
+
+            if (
+                $attributes->type === 'array'
+                && isset($attributes->items)
+                && $attributes->items->type === 'object'
+            ) {
+                $attributes->items->properties = $this->wrapAttributesToArray($attributes->items->properties);
+            }
         }
 
         return $properties;

--- a/tests/Fixtures/Nullable.3.0.json
+++ b/tests/Fixtures/Nullable.3.0.json
@@ -64,6 +64,23 @@
                           }
                         }
                       }
+                    },
+                    "posts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "example": "My first post"
+                          },
+                          "body": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": "Welcome to my blog!"
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/tests/Fixtures/Nullable.3.1.json
+++ b/tests/Fixtures/Nullable.3.1.json
@@ -61,6 +61,22 @@
                           }
                         }
                       }
+                    },
+                    "posts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "example": "My first post"
+                          },
+                          "body": {
+                            "type": ["string", "null"],
+                            "example": "Welcome to my blog!"
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -127,12 +127,16 @@ class ResponseValidatorTest extends TestCase
             $return = [
                 'first_name' => 'Joe',
                 'last_name' => 'Bloggs',
+                'posts' => [
+                    ['title' => 'My first post!']
+                ]
             ];
 
             if ($state === self::NULLABLE_EMPTY) {
                 $return['email'] = '';
                 $return['settings']['last_updated_at'] = '';
                 $return['settings']['notifications']['email'] = '';
+                $return['posts'][0]['body'] = '';
             }
 
             if ($state === self::NULLABLE_VALID) {
@@ -143,12 +147,14 @@ class ResponseValidatorTest extends TestCase
                 $return['email'] = [1, 2, 3];
                 $return['settings']['last_updated_at'] = [1, 2, 3];
                 $return['settings']['notifications']['email'] = [1, 2, 3];
+                $return['posts'][0]['body'] = [1, 2, 3];
             }
 
             if ($state === self::NULLABLE_NULL) {
                 $return['email'] = null;
                 $return['settings']['last_updated_at'] = null;
                 $return['settings']['notifications']['email'] = null;
+                $return['posts'][0]['body'] = null;
             }
 
             return $return;


### PR DESCRIPTION
In a previous PR (#24) I did not take into account the case an array of objects is defined in the schema.
When those objects contain a nullable property the assertions are failing too because the properties are not converted to the JSON-schema array format.

This PR adds support to validate a schema like:
````
"schema": {
  "type": "object",
  "properties": {
    "key": {
      "nested_key": {
        "type": "array", <--- For an array
        "items": {
           "type": "object", <--- of objects
           "properties": {
             "nullable_key": {
             "nullable": true,  <--- this was not checked before
             "type": "string"
           }
         }
      }
    }  
  }
}