### PR TITLE
:sparkles: allow github via personal access token

### DIFF
--- a/config/spectator.php
+++ b/config/spectator.php
@@ -38,7 +38,7 @@ return [
 
         'github' => [
             'source' => 'github',
-            'base_path' => env('SPEC_PATH'),
+            'base_path' => env('SPEC_GITHUB_PATH'),
             'repo' => env('SPEC_GITHUB_REPO'),
             'token' => env('SPEC_GITHUB_TOKEN'),
         ],

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -86,6 +86,13 @@ class RequestFactory
         return $path;
     }
 
+    protected function getGithubPath(array $source, $file)
+    {
+        $path = "https://{$source['token']}@raw.githubusercontent.com/{$source['repo']}/{$source['base_path']}/{$file}";
+
+        return $path;
+    }
+
     protected function standardizePath($path)
     {
         if (! Str::endsWith($path, '/')) {


### PR DESCRIPTION
We are currently using the `remote` option to download the OpenAPI contract file from a remote repo.  However, since including this in our deploy pipeline, we have discovered the Github Raw Access Token is only valid for 7 days.  This means, we must generate a new one and update the `env` file for each deploy.

This PR adds a method that supports the `github` option in the Spectator config file.  The token you need is a Github Personal Access Token (valid for 1 year and longer if you use it regularly).  Instructions for creating that are here (https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)

❕ It is important to note that for the config file option `SPEC_GITHUB_PATH`, you must include the branch.  

Ex: `'base_path' => env('SPEC_GITHUB_PATH', 'master/reference'),`