### PR TITLE
#29 Report on invalid spec files

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
 >
   <coverage processUncoveredFiles="true">
     <include>

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -139,10 +139,9 @@ class Assertions
 
     protected function decodeExceptionMessage()
     {
-        return function ($contents)
-        {
-            if(Arr::get($contents, 'exception') === TypeErrorException::class) {
-                return "The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.";
+        return function ($contents) {
+            if (Arr::get($contents, 'exception') === TypeErrorException::class) {
+                return 'The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.';
             }
 
             return Arr::get($contents, 'message', '');

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -2,10 +2,12 @@
 
 namespace Spectator;
 
+use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
 use Closure;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Spectator\Concerns\HasExpectations;
 use Spectator\Exceptions\InvalidPathException;
 use Spectator\Exceptions\MissingSpecException;
 use Spectator\Exceptions\RequestValidationException;
@@ -14,21 +16,21 @@ use Spectator\Exceptions\ResponseValidationException;
 /** @mixin \Illuminate\Testing\TestResponse|Illuminate\Foundation\Testing\TestResponse */
 class Assertions
 {
+    use HasExpectations;
+
     public function assertValidRequest()
     {
         return function () {
             return $this->runAssertion(function () {
                 $contents = $this->getContent() ? $contents = (array) $this->json() : [];
 
-                PHPUnit::assertFalse(
-                    in_array(Arr::get($contents, 'exception'), [
-                        InvalidPathException::class,
-                        MissingSpecException::class,
-                        RequestValidationException::class,
-                        UnresolvableReferenceException::class,
-                    ]),
-                    $this->decodeExceptionMessage($contents)
-                );
+                $this->expectsFalse($contents, [
+                    InvalidPathException::class,
+                    MissingSpecException::class,
+                    RequestValidationException::class,
+                    TypeErrorException::class,
+                    UnresolvableReferenceException::class,
+                ]);
 
                 return $this;
             });
@@ -41,15 +43,13 @@ class Assertions
             return $this->runAssertion(function () {
                 $contents = (array) $this->json();
 
-                PHPUnit::assertTrue(
-                    in_array(Arr::get($contents, 'exception'), [
-                        InvalidPathException::class,
-                        MissingSpecException::class,
-                        RequestValidationException::class,
-                        UnresolvableReferenceException::class,
-                    ]),
-                    $this->decodeExceptionMessage($contents)
-                );
+                $this->expectsTrue($contents, [
+                    InvalidPathException::class,
+                    MissingSpecException::class,
+                    RequestValidationException::class,
+                    TypeErrorException::class,
+                    UnresolvableReferenceException::class,
+                ]);
 
                 return $this;
             });
@@ -62,13 +62,11 @@ class Assertions
             return $this->runAssertion(function () use ($status) {
                 $contents = $this->getContent() ? (array) $this->json() : [];
 
-                PHPUnit::assertFalse(
-                    in_array(Arr::get($contents, 'exception'), [
-                        ResponseValidationException::class,
-                        UnresolvableReferenceException::class,
-                    ]),
-                    $this->decodeExceptionMessage($contents)
-                );
+                $this->expectsFalse($contents, [
+                    ResponseValidationException::class,
+                    TypeErrorException::class,
+                    UnresolvableReferenceException::class,
+                ]);
 
                 if ($status) {
                     $actual = $this->getStatusCode();
@@ -90,13 +88,11 @@ class Assertions
             return $this->runAssertion(function () use ($status) {
                 $contents = (array) $this->json();
 
-                PHPUnit::assertTrue(
-                    in_array(Arr::get($contents, 'exception'), [
-                        ResponseValidationException::class,
-                        UnresolvableReferenceException::class,
-                    ]),
-                    $this->decodeExceptionMessage($contents)
-                );
+                $this->expectsTrue($contents, [
+                    ResponseValidationException::class,
+                    TypeErrorException::class,
+                    UnresolvableReferenceException::class,
+                ]);
 
                 if ($status) {
                     $actual = $this->getStatusCode();
@@ -116,7 +112,7 @@ class Assertions
     {
         return function ($expected) {
             return $this->runAssertion(function () use ($expected) {
-                $actual = $this->getData()->message;
+                $actual = $this->decodeExceptionMessage((array) $this->json());
 
                 PHPUnit::assertSame(
                     $expected, $actual,
@@ -143,7 +139,12 @@ class Assertions
 
     protected function decodeExceptionMessage()
     {
-        return function ($contents) {
+        return function ($contents)
+        {
+            if(Arr::get($contents, 'exception') === TypeErrorException::class) {
+                return "The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.";
+            }
+
             return Arr::get($contents, 'message', '');
         };
     }

--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Spectator\Concerns;
+
+
+use cebe\openapi\exceptions\TypeErrorException;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait HasExpectations
+{
+    public function expectsFalse()
+    {
+        return function($contents, array $exceptions) {
+            $exception = $this->exceptionType($contents);
+
+            PHPUnit::assertFalse(
+                in_array($exception, $exceptions),
+                $this->decodeExceptionMessage($contents)
+            );
+        };
+    }
+
+    public function expectsTrue()
+    {
+        return function($contents, array $exceptions) {
+            $exception = $this->exceptionType($contents);
+
+            PHPUnit::assertTrue(
+                in_array($exception, $exceptions),
+                $this->decodeExceptionMessage($contents)
+            );
+        };
+    }
+
+    public function exceptionType()
+    {
+        return function ($contents)
+        {
+            return Arr::get($contents, 'exception');
+        };
+    }
+
+}

--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace Spectator\Concerns;
 
-
-use cebe\openapi\exceptions\TypeErrorException;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -12,7 +9,7 @@ trait HasExpectations
 {
     public function expectsFalse()
     {
-        return function($contents, array $exceptions) {
+        return function ($contents, array $exceptions) {
             $exception = $this->exceptionType($contents);
 
             PHPUnit::assertFalse(
@@ -24,7 +21,7 @@ trait HasExpectations
 
     public function expectsTrue()
     {
-        return function($contents, array $exceptions) {
+        return function ($contents, array $exceptions) {
             $exception = $this->exceptionType($contents);
 
             PHPUnit::assertTrue(
@@ -36,10 +33,8 @@ trait HasExpectations
 
     public function exceptionType()
     {
-        return function ($contents)
-        {
+        return function ($contents) {
             return Arr::get($contents, 'exception');
         };
     }
-
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -10,7 +10,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Str;
-use Spectator\Concerns\ValidatesRequests;
 use Spectator\Exceptions\InvalidMethodException;
 use Spectator\Exceptions\InvalidPathException;
 use Spectator\Exceptions\MissingSpecException;
@@ -42,7 +41,7 @@ class Middleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if (!$this->spectator->getSpec()) {
+        if (! $this->spectator->getSpec()) {
             return $next($request);
         }
 
@@ -50,11 +49,11 @@ class Middleware
             $response = $this->validate($request, $next);
         } catch (InvalidPathException $exception) {
             return $this->formatResponse($exception, 422);
-        } catch (RequestValidationException|ResponseValidationException $exception) {
+        } catch (RequestValidationException | ResponseValidationException $exception) {
             return $this->formatResponse($exception, 400);
         } catch (InvalidMethodException $exception) {
             return $this->formatResponse($exception, 405);
-        } catch (MissingSpecException|UnresolvableReferenceException|TypeErrorException|Throwable $exception) {
+        } catch (MissingSpecException | UnresolvableReferenceException | TypeErrorException | Throwable $exception) {
             return $this->formatResponse($exception, 500);
         }
 
@@ -111,8 +110,8 @@ class Middleware
      */
     protected function operation($request_path, $request_method): Operation
     {
-        if (!Str::startsWith($request_path, '/')) {
-            $request_path = '/' . $request_path;
+        if (! Str::startsWith($request_path, '/')) {
+            $request_path = '/'.$request_path;
         }
 
         $openapi = $this->spectator->resolve();
@@ -146,6 +145,6 @@ class Middleware
             return trim($part, $separator);
         }, [config('spectator.path_prefix'), $path]));
 
-        return $separator . implode($separator, $parts);
+        return $separator.implode($separator, $parts);
     }
 }

--- a/tests/Fixtures/Malformed.v1.yaml
+++ b/tests/Fixtures/Malformed.v1.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: Test.v1
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+tags:
+  - "I don't"
+  - "know what"
+  - "I'm doing"
+paths:
+  /:
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+      operationId: get-api-testing
+      description: A testing endpoint
+components:
+  schemas: null
+  responses: null
+  headers: null
+  parameters: null
+  links: null
+  examples: null

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -120,8 +120,7 @@ class ResponseValidatorTest extends TestCase
         $version,
         $state,
         $is_valid
-    )
-    {
+    ) {
         Spectator::using("Nullable.{$version}.json");
 
         Route::get('/users/{user}', function () use ($state) {

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -120,7 +120,8 @@ class ResponseValidatorTest extends TestCase
         $version,
         $state,
         $is_valid
-    ) {
+    )
+    {
         Spectator::using("Nullable.{$version}.json");
 
         Route::get('/users/{user}', function () use ($state) {
@@ -236,5 +237,17 @@ class ResponseValidatorTest extends TestCase
                 $invalidResponse,
             ],
         ];
+    }
+
+    public function test_handles_invalid_spec()
+    {
+        Spectator::using('Malformed.v1.yaml');
+
+        Route::get('/')->middleware(Middleware::class);
+
+        $this->getJson('/')
+            ->assertInvalidRequest()
+            ->assertInvalidResponse()
+            ->assertValidationMessage('The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.');
     }
 }


### PR DESCRIPTION
This resolves an issue where exceptions for invalid spec files are not providing clear error messaging.

Resolves https://github.com/hotmeteor/spectator/issues/29