### PR TITLE
#32 Output full exception stack trace when exception handling is disabled in a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,44 @@ $this
     ])
     ->assertValidRequest()
     ->assertValidResponse(201);
-````
-  
+```
+
+When exceptions are thrown that are not specific to this package's purpose, e.g. typo's or missing imports, the output will be formatted by default with a rather short message and no stack trace.
+This can be changed by disabling Laravel's built in validation handler which allows for easier debugging when running tests.
+
+This can be done in a few different ways:
+
+```php
+class ExampleTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Spectator::using('Api.v1.json');
+
+        // Disable exception handling for all tests in this file
+        $this->withoutExceptionHandling();
+    }
+
+    // ...
+}
+```
+
+```php
+class ExampleTestCase
+{
+    public function test_some_contract_test_example(): void
+    {
+        // Only disable exception handling for this test
+        $this->withouthExceptionHandling();
+
+        // Test request and response ...
+
+    }
+}
+```
+
 ## Credits
 
 - [Adam Campbell](https://github.com/hotmeteor)

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -41,7 +41,7 @@ class Middleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if (!$this->spectator->getSpec()) {
+        if (! $this->spectator->getSpec()) {
             return $next($request);
         }
 
@@ -116,7 +116,7 @@ class Middleware
      */
     protected function operation($request_path, $request_method): Operation
     {
-        if (!Str::startsWith($request_path, '/')) {
+        if (! Str::startsWith($request_path, '/')) {
             $request_path = '/' . $request_path;
         }
 
@@ -151,6 +151,6 @@ class Middleware
             return trim($part, $separator);
         }, [config('spectator.path_prefix'), $path]));
 
-        return $separator . implode($separator, $parts);
+        return $separator.implode($separator, $parts);
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -116,7 +116,7 @@ class Middleware
     protected function operation($request_path, $request_method): Operation
     {
         if (! Str::startsWith($request_path, '/')) {
-            $request_path = '/' . $request_path;
+            $request_path = '/'.$request_path;
         }
 
         $openapi = $this->spectator->resolve();

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -18,7 +18,6 @@ use Spectator\Exceptions\RequestValidationException;
 use Spectator\Exceptions\ResponseValidationException;
 use Spectator\Validation\RequestValidator;
 use Spectator\Validation\ResponseValidator;
-use Throwable;
 
 class Middleware
 {

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -114,7 +114,7 @@ class ResponseValidatorTest extends TestCase
             ->assertValidResponse(200);
     }
 
-    public function testUncaughtExceptionsAreThrownWhenExceptionHandlingIsDisabled(): void
+    public function test_uncaught_exceptions_are_thrown_when_exception_handling_is_disabled(): void
     {
         Route::get('/users', function () {
             throw new Exception('Something went wrong in the codebase!');

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -117,17 +117,18 @@ class ResponseValidatorTest extends TestCase
     public function testUncaughtExceptionsAreThrownWhenExceptionHandlingIsDisabled(): void
     {
         Route::get('/users', function () {
-            throw new Exception("Something went wrong in the codebase!");
+            throw new Exception('Something went wrong in the codebase!');
         })->middleware(Middleware::class);
 
         try {
             $this->withoutExceptionHandling()->getJson('/users');
         } catch (Exception $e) {
-            $this->assertEquals("Something went wrong in the codebase!", $e->getMessage());
+            $this->assertEquals('Something went wrong in the codebase!', $e->getMessage());
+
             return;
         }
 
-        $this->fail("Failed asserting an exception was thrown");
+        $this->fail('Failed asserting an exception was thrown');
     }
 
     /**

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Spectator\Tests;
 
+use Exception;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Spectator\Middleware;
@@ -111,6 +112,22 @@ class ResponseValidatorTest extends TestCase
         $this->getJson('/api/v2/users')
             ->assertValidRequest()
             ->assertValidResponse(200);
+    }
+
+    public function testUncaughtExceptionsAreThrownWhenExceptionHandlingIsDisabled(): void
+    {
+        Route::get('/users', function () {
+            throw new Exception("Something went wrong in the codebase!");
+        })->middleware(Middleware::class);
+
+        try {
+            $this->withoutExceptionHandling()->getJson('/users');
+        } catch (Exception $e) {
+            $this->assertEquals("Something went wrong in the codebase!", $e->getMessage());
+            return;
+        }
+
+        $this->fail("Failed asserting an exception was thrown");
     }
 
     /**


### PR DESCRIPTION
This PR will introduce the ability to have a full stack trace output when exception handling is disabled.
When running tests it's nicer to have the full output when an uncaught exception occurs in the codebase for debugging.

Exceptions related to invalid spec and such remain unchanged and are formatted with a useful message.

Resolves: #32 