### PR TITLE
Add a failing test showing that "nullable" is not accepted for fields with type string and a format

### DIFF
--- a/tests/Fixtures/Nullable.3.0.json
+++ b/tests/Fixtures/Nullable.3.0.json
@@ -47,6 +47,7 @@
                     },
                     "website": {
                       "type": "string",
+                      "format": "uri",
                       "example": "https://example.org",
                       "nullable": true
                     },

--- a/tests/Fixtures/Nullable.3.0.json
+++ b/tests/Fixtures/Nullable.3.0.json
@@ -45,6 +45,11 @@
                       "example": "test@test.com",
                       "nullable": true
                     },
+                    "website": {
+                      "type": "string",
+                      "example": "https://example.org",
+                      "nullable": true
+                    },
                     "settings": {
                       "type": "object",
                       "properties": {

--- a/tests/Fixtures/Nullable.3.1.json
+++ b/tests/Fixtures/Nullable.3.1.json
@@ -44,6 +44,10 @@
                       "type": ["string", "null"],
                       "example": "test@test.com"
                     },
+                    "website": {
+                      "type": ["string", "null"],
+                      "example": "https://example.org"
+                    },
                     "settings": {
                       "type": "object",
                       "properties": {

--- a/tests/Fixtures/Nullable.3.1.json
+++ b/tests/Fixtures/Nullable.3.1.json
@@ -46,6 +46,7 @@
                     },
                     "website": {
                       "type": ["string", "null"],
+                      "format": "uri",
                       "example": "https://example.org"
                     },
                     "settings": {

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -152,17 +152,20 @@ class ResponseValidatorTest extends TestCase
 
             if ($state === self::NULLABLE_EMPTY) {
                 $return['email'] = '';
+                $return['website'] = '';
                 $return['settings']['last_updated_at'] = '';
                 $return['settings']['notifications']['email'] = '';
                 $return['posts'][0]['body'] = '';
             }
 
             if ($state === self::NULLABLE_VALID) {
+                $return['website'] = 'https://example.org';
                 $return['email'] = 'test@test.com';
             }
 
             if ($state === self::NULLABLE_INVALID) {
                 $return['email'] = [1, 2, 3];
+                $return['website'] = [1, 2, 3];
                 $return['settings']['last_updated_at'] = [1, 2, 3];
                 $return['settings']['notifications']['email'] = [1, 2, 3];
                 $return['posts'][0]['body'] = [1, 2, 3];
@@ -170,6 +173,7 @@ class ResponseValidatorTest extends TestCase
 
             if ($state === self::NULLABLE_NULL) {
                 $return['email'] = null;
+                $return['website'] = null;
                 $return['settings']['last_updated_at'] = null;
                 $return['settings']['notifications']['email'] = null;
                 $return['posts'][0]['body'] = null;


### PR DESCRIPTION
When a nullable string field gets assigned a "format" (e.g. date, date-time, uri,...), the "nullable" modifier (or potential null value for v3.1) is not accepted anymore.

I'm not entirely sure how this should be fixed (probably not even in this library but in the underlying schema validator package?) but this already adds a test proving the problem.

I wouldn't mind helping to fix this if I could get a couple of pointers where you'd expect this to be fixed.