### PR TITLE
Improved request assertion message rendering breaks on Laravel's request validation response

### DIFF
--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -60,7 +60,7 @@ class AssertionsTest extends TestCase
             throw ValidationException::withMessages([
                 'email' => [
                     'The provided email address is already taken.',
-                ]
+                ],
             ]);
         })->middleware(Middleware::class);
 

--- a/tests/Fixtures/Test.v1.json
+++ b/tests/Fixtures/Test.v1.json
@@ -80,6 +80,9 @@
         "responses": {
           "201": {
             "description": "Created"
+          },
+          "422": {
+            "description": "Unprocessable Entity"
           }
         },
         "operationId": "post-users",


### PR DESCRIPTION
Been using the package for a while and bumped into this issue with the latest version (v1.1.0 at the moment of writing):

In tests that cover a scenario that expects a 422 status code and a default Laravel validation response there is an `Array to string conversion` exception when the assertion message is formatted [here](https://github.com/hotmeteor/spectator/blob/master/src/Concerns/HasExpectations.php#L77).

I've added a test that shows this scenario. Unsure at the moment myself on how to resolve this properly.

