### PR TITLE
#49 Allow for Laravel validation to pass through

### DIFF
--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -54,7 +54,7 @@ trait HasExpectations
 
             $message = trim(Arr::get($contents, 'message'));
 
-            if (isset($contents['errors']) && count($contents['errors']) > 0 && ! config('spectator.suppress_errors')) {
+            if (isset($contents['specErrors']) && count($contents['specErrors']) > 0 && ! config('spectator.suppress_errors')) {
                 $output = new ConsoleOutput();
 
                 $table = new Table($output);
@@ -71,7 +71,7 @@ trait HasExpectations
                     ),
                 ]);
 
-                $errors = array_filter($contents['errors'], fn ($item) => $item !== $message);
+                $errors = array_filter($contents['specErrors'], fn ($item) => $item !== $message);
 
                 foreach ($errors as $error) {
                     $table->addRow(["<fg=red>⨯</> <fg=white>{$error}</>"]);

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -73,7 +73,7 @@ class Middleware
     protected function formatResponse($exception, $code): JsonResponse
     {
         $errors = method_exists($exception, 'getErrors')
-            ? ['errors' => $exception->getErrors()]
+            ? ['specErrors' => $exception->getErrors()]
             : [];
 
         return Response::json(array_merge([

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Spectator\Tests;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Validation\ValidationException;
 use Spectator\Middleware;
 use Spectator\Spectator;
 use Spectator\SpectatorServiceProvider;
@@ -48,5 +50,27 @@ class AssertionsTest extends TestCase
         $this->getJson('/users')
             ->assertValidRequest()
             ->assertValidResponse(200);
+    }
+
+    public function test_request_assertion_does_not_format_laravel_validation_response_errors_when_errors_are_not_suppressed(): void
+    {
+        Config::set('spectator.suppress_errors', false);
+
+        Route::post('/users', function () {
+            throw ValidationException::withMessages([
+                'email' => [
+                    'The provided email address is already taken.',
+                ],
+            ]);
+        })->middleware(Middleware::class);
+
+        $response = $this->postJson('/users', [
+            'name' => 'Jane Doe',
+            'email' => 'jane.doe@example.com',
+        ]);
+
+        $response
+            ->assertValidRequest()
+            ->assertValidResponse(422);
     }
 }

--- a/tests/Fixtures/Test.v1.json
+++ b/tests/Fixtures/Test.v1.json
@@ -80,6 +80,9 @@
         "responses": {
           "201": {
             "description": "Created"
+          },
+          "422": {
+            "description": "Unprocessable Entity"
           }
         },
         "operationId": "post-users",


### PR DESCRIPTION
Renames spec error key as to not overwrite Laravel errors.

Refs https://github.com/hotmeteor/spectator/pull/49