### PR TITLE
Fix php8.1 deprecation warning

### DIFF
--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -52,7 +52,7 @@ trait HasExpectations
                 return 'The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.';
             }
 
-            $message = trim(Arr::get($contents, 'message'));
+            $message = trim(Arr::get($contents, 'message', ''));
 
             if (isset($contents['specErrors']) && count($contents['specErrors']) > 0 && ! config('spectator.suppress_errors')) {
                 $output = new ConsoleOutput();


### PR DESCRIPTION
Fixes deprecation 
```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated
```

If `message` is not found in `$contents`, `Arr::get($contents, 'message')` returns `null`.

