### PR TITLE
Add support for binary string in form data

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -198,16 +198,17 @@ class RequestValidator extends AbstractValidator
     {
         $body = array_merge_recursive(
             $this->request->request->all(),
-            array_map(function(UploadedFile $file) {
+            array_map(function (UploadedFile $file) {
                 return $file->get();
-            },$this->request->allFiles())
+            }, $this->request->allFiles())
         );
 
         return $this->toObject($body);
     }
 
-    private function toObject($data) {
-        if (!is_array($data)) {
+    private function toObject($data)
+    {
+        if (! is_array($data)) {
             return $data;
         } elseif (is_numeric(key($data))) {
             return array_map([$this, 'toObject'], $data);

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -5,6 +5,7 @@ namespace Spectator\Validation;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\PathItem;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
 use Spectator\Exceptions\RequestValidationException;
@@ -164,11 +165,11 @@ class RequestValidator extends AbstractValidator
         $expected_body_raw_schema = $expected_body->content[$content_type]->schema;
         $actual_body_schema = $actual_body;
         if ($expected_body_raw_schema->type === 'object' || $expected_body_raw_schema->type === 'array' || $expected_body_raw_schema->oneOf || $expected_body_raw_schema->anyOf) {
-            if (! in_array($content_type, ['application/json', 'application/vnd.api+json'])) {
-                throw new RequestValidationException("Unable to map [{$content_type}] to schema type [object].");
+            if (in_array($content_type, ['application/json', 'application/vnd.api+json'])) {
+                $actual_body_schema = json_decode($actual_body_schema);
+            } else {
+                $actual_body_schema = $this->parseBodySchema();
             }
-
-            $actual_body_schema = json_decode($actual_body_schema);
         }
         $expected_body_schema = $this->prepareData($expected_body_raw_schema);
 
@@ -191,5 +192,27 @@ class RequestValidator extends AbstractValidator
     protected function operation(): Operation
     {
         return $this->pathItem->{$this->method};
+    }
+
+    protected function parseBodySchema(): object
+    {
+        $body = array_merge_recursive(
+            $this->request->request->all(),
+            array_map(function(UploadedFile $file) {
+                return $file->get();
+            },$this->request->allFiles())
+        );
+
+        return $this->toObject($body);
+    }
+
+    private function toObject($data) {
+        if (!is_array($data)) {
+            return $data;
+        } elseif (is_numeric(key($data))) {
+            return array_map([$this, 'toObject'], $data);
+        } else {
+            return (object) array_map([$this, 'toObject'], $data);
+        }
     }
 }

--- a/tests/Fixtures/BinaryString.v1.json
+++ b/tests/Fixtures/BinaryString.v1.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test.v1",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "post": {
+        "summary": "Create user",
+        "tags": [],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "422": {
+            "description": "Unprocessable Entity"
+          }
+        },
+        "operationId": "post-users",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "Adam Campbell"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "example": "test@test.com"
+                  },
+                  "picture": {
+                    "type": "string",
+                    "format": "binary",
+                    "example": "SGVsbG8gV29ybGQ="
+                  }
+                },
+                "required": [
+                  "name",
+                  "email",
+                  "picture"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}


### PR DESCRIPTION
This PR allows to test requests using `multipart/form-data`.

This can be handy as  `multipart/form-data` requests can have files attached.

In OpenApi, a file is defined as `string` with `binary` format