### PR TITLE
Avoid TypeError when `formatSchema` function does not return array

### DIFF
--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -287,9 +287,9 @@ abstract class SchemaValidationException extends \Exception implements Exception
                         break;
                 }
             }
-
-            return $schema_map;
         }
+
+        return $schema_map;
     }
 
     /**


### PR DESCRIPTION
This function causes a `TypeError` on return when neither conditions is true.