### PR TITLE
Parameter type check and casting

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -121,6 +121,10 @@ class RequestValidator extends AbstractValidator
                 }
 
                 if ($actual_parameter) {
+                    if($expected_parameter_schema->type && gettype($actual_parameter) !== $expected_parameter_schema->type){
+                        settype($actual_parameter, $expected_parameter_schema->type);
+                    }
+
                     $result = $validator->validate($actual_parameter, $expected_parameter_schema);
 
                     // If the result is not valid, then display failure reason.

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -121,7 +121,7 @@ class RequestValidator extends AbstractValidator
                 }
 
                 if ($actual_parameter) {
-                    if($expected_parameter_schema->type && gettype($actual_parameter) !== $expected_parameter_schema->type){
+                    if ($expected_parameter_schema->type && gettype($actual_parameter) !== $expected_parameter_schema->type) {
                         settype($actual_parameter, $expected_parameter_schema->type);
                     }
 

--- a/tests/Fixtures/Test.v1.json
+++ b/tests/Fixtures/Test.v1.json
@@ -197,6 +197,46 @@
         "operationId": "get-users-user"
       }
     },
+    "/users-by-id/{user}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "integer"
+          },
+          "name": "user",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "Get a single user",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-users-user"
+      }
+    },
     "/posts/{postUuid}": {
       "parameters": [
         {

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -452,6 +452,19 @@ class RequestValidatorTest extends TestCase
         $this->getJson('/users?order=name')
             ->assertValidRequest();
     }
+
+    public function test_handles_query_parameters_int()
+    {
+        Spectator::using('Test.v1.json');
+
+        // When testing query parameters, they are not found nor checked by RequestValidator->validateParameters().
+        Route::get('/users-by-id/{user}', function (int $user) {
+            return [];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/users-by-id/1')
+            ->assertValidRequest();
+    }
 }
 
 class TestUser extends Model


### PR DESCRIPTION
Hello,

this PR should fix #87 . 
So the parameters should be casted to their expected type.
The alternative would be to check the types before with i.e. is_numeric. But then it would be a bigger if/else block.
But if you like it better I can change that.