### PR TITLE
Fix parse body schema

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -199,7 +199,7 @@ class RequestValidator extends AbstractValidator
     {
         $body = $this->request->all();
 
-        array_walk_recursive($body, function(&$value){
+        array_walk_recursive($body, function (&$value) {
             if ($value instanceof UploadedFile) {
                 $value = $value->get();
             }

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -6,6 +6,7 @@ use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\PathItem;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
 use Spectator\Exceptions\RequestValidationException;
@@ -196,12 +197,12 @@ class RequestValidator extends AbstractValidator
 
     protected function parseBodySchema(): object
     {
-        $body = array_merge_recursive(
-            $this->request->request->all(),
-            array_map(function (UploadedFile $file) {
-                return $file->get();
-            }, $this->request->allFiles())
-        );
+        $body = Arr::undot(array_map(
+            function ($item) {
+                return $item instanceof UploadedFile ? $item->get() : $item;
+            },
+            Arr::dot($this->request->all())
+        ));
 
         return $this->toObject($body);
     }

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -211,10 +211,10 @@ class RequestValidator extends AbstractValidator
     {
         if (! is_array($data)) {
             return $data;
-        } elseif (is_numeric(key($data))) {
-            return array_map([$this, 'toObject'], $data);
-        } else {
+        } elseif (Arr::isAssoc($data)) {
             return (object) array_map([$this, 'toObject'], $data);
+        } else {
+            return array_map([$this, 'toObject'], $data);
         }
     }
 }

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -197,12 +197,13 @@ class RequestValidator extends AbstractValidator
 
     protected function parseBodySchema(): object
     {
-        $body = Arr::undot(array_map(
-            function ($item) {
-                return $item instanceof UploadedFile ? $item->get() : $item;
-            },
-            Arr::dot($this->request->all())
-        ));
+        $body = $this->request->all();
+
+        array_walk_recursive($body, function(&$value){
+            if ($value instanceof UploadedFile) {
+                $value = $value->get();
+            }
+        });
 
         return $this->toObject($body);
     }

--- a/tests/Fixtures/BinaryString.v1.json
+++ b/tests/Fixtures/BinaryString.v1.json
@@ -54,6 +54,81 @@
           }
         }
       }
+    },
+    "/users/multiple-files": {
+      "post": {
+        "summary": "Send multiple files in structure",
+        "tags": [],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "422": {
+            "description": "Unprocessable Entity"
+          }
+        },
+        "operationId": "post-users-multiple-files",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "picture": {
+                    "type": "string",
+                    "format": "binary",
+                    "example": "SGVsbG8gV29ybGQ="
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "example": "file.txt"
+                        },
+                        "file": {
+                          "type": "string",
+                          "format": "binary",
+                          "example": "SGVsbG8gV29ybGQ="
+                        },
+                        "required": [
+                          "name",
+                          "file"
+                        ]
+                      }
+                    }
+                  },
+                  "resume": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "example": "file.txt"
+                      },
+                      "file": {
+                        "type": "string",
+                        "format": "binary",
+                        "example": "SGVsbG8gV29ybGQ="
+                      },
+                      "required": [
+                        "name",
+                        "file"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "picture",
+                  "files",
+                  "resume"
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -546,6 +546,33 @@ class RequestValidatorTest extends TestCase
         )
             ->assertValidRequest();
     }
+
+    public function test_handles_form_data_with_multiple_files()
+    {
+        Spectator::using('BinaryString.v1.json');
+
+        Route::post('/users/multiple-files', function () {
+            return [];
+        })->middleware(Middleware::class);
+
+        $this->withoutExceptionHandling()
+            ->post(
+            '/users/multiple-files',
+            [
+                'picture' => UploadedFile::fake()->image('test.jpg'),
+                'files' => [
+                    ['name' => 'test.jpg', 'file' => UploadedFile::fake()->image('test.jpg')],
+                    ['name' => 'test.jpg', 'file' => UploadedFile::fake()->image('test.jpg')],
+                ],
+                'resume' => [
+                    'name' => 'test.pdf',
+                    'file' => UploadedFile::fake()->create('test.pdf'),
+                ]
+            ],
+            ['Content-Type' => 'multipart/form-data']
+        )
+            ->assertValidRequest();
+    }
 }
 
 class TestUser extends Model

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -566,7 +566,7 @@ class RequestValidatorTest extends TestCase
                 'resume' => [
                     'name' => 'test.pdf',
                     'file' => UploadedFile::fake()->create('test.pdf'),
-                ]
+                ],
             ],
             ['Content-Type' => 'multipart/form-data']
         )
@@ -580,7 +580,7 @@ class RequestValidatorTest extends TestCase
                 'resume' => [
                     'name' => 'test.pdf',
                     'file' => UploadedFile::fake()->create('test.pdf'),
-                ]
+                ],
             ],
             ['Content-Type' => 'multipart/form-data']
         )

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -555,8 +555,7 @@ class RequestValidatorTest extends TestCase
             return [];
         })->middleware(Middleware::class);
 
-        $this->withoutExceptionHandling()
-            ->post(
+        $this->post(
             '/users/multiple-files',
             [
                 'picture' => UploadedFile::fake()->image('test.jpg'),
@@ -564,6 +563,20 @@ class RequestValidatorTest extends TestCase
                     ['name' => 'test.jpg', 'file' => UploadedFile::fake()->image('test.jpg')],
                     ['name' => 'test.jpg', 'file' => UploadedFile::fake()->image('test.jpg')],
                 ],
+                'resume' => [
+                    'name' => 'test.pdf',
+                    'file' => UploadedFile::fake()->create('test.pdf'),
+                ]
+            ],
+            ['Content-Type' => 'multipart/form-data']
+        )
+            ->assertValidRequest();
+
+        $this->withoutExceptionHandling()->post(
+            '/users/multiple-files',
+            [
+                'picture' => UploadedFile::fake()->image('test.jpg'),
+                'files' => [],
                 'resume' => [
                     'name' => 'test.pdf',
                     'file' => UploadedFile::fake()->create('test.pdf'),


### PR DESCRIPTION
This PR fixes 2 bugs of #82 

Firstly, it fixes `UploadedFile` transformation  to string when they are deep in the request.
For exemple 
```php
[
    'picture' => UploadedFile::fake()->image('test.jpg'),
    'files' => [
        ['name' => 'test.jpg', 'file' => UploadedFile::fake()->image('test.jpg')],
        ['name' => 'test.jpg', 'file' => UploadedFile::fake()->image('test.jpg')],
    ],
    'resume' => [
        'name' => 'test.pdf',
        'file' => UploadedFile::fake()->create('test.pdf'),
    ]
],
```

Secondly, it does not cast empty arrays to object when the array is empty.
In
```php
[
  'picture' => UploadedFile::fake()->image('test.jpg'),
  'files' => [],
  'resume' => [
      'name' => 'test.pdf',
      'file' => UploadedFile::fake()->create('test.pdf'),
  ]
]
  ```
  `files` must stay an array.