### PR TITLE
Add Laravel 9 support, drop Laravel 7 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,14 +13,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: [ 7.30.*, 8.* ]
-        php: [ 7.4, 8.0 ]
+        laravel: [ 8.*, 9.* ]
+        php: [ 7.4, 8.0, 8.1 ]
         include:
-          - laravel: 7.30.*
-            testbench: 5.*
           - laravel: 8.*
             testbench: 6.*
-            
+          - laravel: 9.*
+            testbench: 7.*
+        exclude:
+          - laravel: 9.*
+            php: 7.4
+
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "php": "^7.4|^8.0",
     "ext-json": "*",
     "cebe/php-openapi": "^1.5",
-    "laravel/framework": "^7.30.3|^8.40.0",
+    "laravel/framework": "^8.40.0|^9.0.0",
     "opis/json-schema": "^2.0"
   },
   "require-dev": {
-    "nunomaduro/collision": "^4.0|^5.1",
-    "orchestra/testbench": "^5.0|^6.0",
-    "phpunit/phpunit": "^8.0|^9.0"
+    "nunomaduro/collision": "^5.1|^6.0",
+    "orchestra/testbench": "^6.0|^7.0",
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -3,11 +3,9 @@
 namespace Spectator;
 
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\TestResponse;
-use LogicException;
 
 class SpectatorServiceProvider extends ServiceProvider
 {
@@ -41,21 +39,7 @@ class SpectatorServiceProvider extends ServiceProvider
 
     protected function decorateTestResponse()
     {
-        // Laravel >= 7.0
-        if (class_exists(TestResponse::class)) {
-            TestResponse::mixin(new Assertions());
-
-            return;
-        }
-
-        // Laravel <= 6.0
-        if (class_exists(LegacyTestResponse::class)) {
-            LegacyTestResponse::mixin(new Assertions());
-
-            return;
-        }
-
-        throw new LogicException('Could not detect TestResponse class.');
+        TestResponse::mixin(new Assertions());
     }
 
     protected function getConfigPath()


### PR DESCRIPTION
`cebe/php-openapi` just dropped support for `symfony/yaml:^6.0` which allows us to bring support for Laravel 9.

I dropped support for Laravel 7 which is end of life.

I also added tests under PHP 8.1