### PR TITLE
Reset array keys when formatting schema exception

### DIFF
--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -180,7 +180,7 @@ abstract class SchemaValidationException extends \Exception implements Exception
         $polymorphic_keys = array_filter($keys_at_location, function ($key) {
             return $key == 'allOf' || $key == 'anyOf' || $key == 'oneOf';
         }, ARRAY_FILTER_USE_KEY);
-        $polymorphic_keys = array_flip($polymorphic_keys);
+        $polymorphic_keys = array_values(array_flip($polymorphic_keys));
 
         if (! empty($polymorphic_keys)) { // first, check for a polymorphic schema...
             $polymorphic_key = $polymorphic_keys[0];


### PR DESCRIPTION
This PR fixes the exception output when the `array_filter(...)` method returns an array with keys like this:

```php
$polymorphic_keys = [
    2 => 'allOf',
]
```

When that happens the next lines assume a key `0` to be present. Without resetting the keys the exception output cannot be formatted properly to a readable message regarding the schema validation itself.

Not entirely sure which OpenAPI structure exactly is triggering this behaviour in the project I'm working on.
Anyway I'm pretty convinced this could happen to others too. 🤷‍♂️ 