### PR TITLE
Feature/allow schema problem json

### DIFF
--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -150,7 +150,7 @@ class ResponseValidator extends AbstractValidator
         $body = $this->response->getContent();
 
         if (in_array($schemaType, ['object', 'array', 'allOf', 'anyOf', 'oneOf'], true)) {
-            if (in_array($contentType, ['application/json', 'application/vnd.api+json'])) {
+            if (in_array($contentType, ['application/json', 'application/problem+json', 'application/vnd.api+json'])) {
                 return json_decode($body);
             } else {
                 throw new ResponseValidationException("Unable to map [{$contentType}] to schema type [object].");

--- a/tests/Fixtures/ProblemJson.yaml
+++ b/tests/Fixtures/ProblemJson.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Problem Json
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /users:
+    get:
+      summary: Get users
+      tags: []
+      responses:
+        '500':
+          description: "Error internal"
+          content:
+            application/problem+json:
+              schema:
+                type: object
+                additionalProperties: true
+                minProperties: 5
+                description: >-
+                  The issue details in JSON format [[RFC7807](https://tools.ietf.org/html/rfc7807)].
+                properties:
+                  type:
+                    type: string
+                    description: >-
+                      A URL [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a page with more details regarding the problem.
+                      Type is typically an absolute URL that leads to an HTML page containing human-readable documentation regarding the problem.
+                      When type is not provided (undefined) the consumers must assume that type equals about:blank.
+                  title:
+                    type: string
+                    description: >-
+                      Short human-readable summary of the problem.
+                      If type is specified then title should not equal the description of the HTTP status code.
+                      When type equals about:blank then title should equal the description of the HTTP status code.
+                  status:
+                    type: integer
+                    description: The HTTP status code.
+                    minimum: 400
+                    maximum: 599
+                  detail:
+                    type: string
+                    description: >-
+                      Human-readable description of this specific problem.
+                  instance:
+                    type: string
+                    description: >-
+                      A URI that describes where the problem occurred.
+components:
+  schemas: {}

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -5,6 +5,7 @@ namespace Spectator\Tests;
 use Exception;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Str;
 use Spectator\Middleware;
 use Spectator\Spectator;
@@ -586,5 +587,23 @@ class ResponseValidatorTest extends TestCase
                 'All array items must match schema',
                 'The data (array) must match the type: object',
             ]);
+    }
+
+    public function test_validates_schema_problem_json_response_when_invalid()
+    {
+        Spectator::using('ProblemJson.yaml');
+        Route::get('/users', function () {
+            return Response::json([
+                'type' => 'about:blank',
+                'title' => 'Internal Server Error',
+                'status' => 500,
+                'details' => 'Error',
+                'instance' => '/users',
+            ], 500, ['Content-Type' => 'application/problem+json']);
+        })->middleware(Middleware::class);
+
+        $response = $this->getJson('/users');
+        $response->assertValidRequest()
+            ->assertValidResponse(500);
     }
 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -4,8 +4,8 @@ namespace Spectator\Tests;
 
 use Exception;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Spectator\Middleware;
 use Spectator\Spectator;


### PR DESCRIPTION
This feature allows when an API returns errors in the pattern of [RFC7807](https://datatracker.ietf.org/doc/html/rfc7807), in which the content-type returned is `application/problem+json` passes contract validation tests.

The reason for this feature is because it has an API following this pattern and when testing the tests with error, it returns

```
• Tests\Contract\States\StateContractTest > returns 500 for list states
    ErrorException

   Unable to map [application/problem+json] to schema type [object].
Failed asserting that true is false.
```

And when you add the content-type `application/problem+json` to the ResponseValidator in the body method, the test is accepted.