### PR TITLE
Add type hinting to `$path` param

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -172,11 +172,7 @@ class Middleware
         throw new InvalidPathException("Path [{$request_method} {$request_path}] not found in spec.", 404);
     }
 
-    /**
-     * @param $path
-     * @return string
-     */
-    protected function resolvePath($path): string
+    protected function resolvePath(string $path): string
     {
         $separator = '/';
 


### PR DESCRIPTION
* `$path` param had missing type. The library supports at least PHP 7.4, so `string` type declaration can be added there.
* Remove redundant doBlock (as we now have the them in the function signature).

Hope it helps @hotmeteor! 🙂