### PR TITLE
Skip request validation

### DIFF
--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -15,6 +15,7 @@ namespace Illuminate\Testing {
      * @method static assertInvalidResponse($status = null)
      * @method static assertValidationMessage($expected)
      * @method static assertErrorsContain($errors)
+     * @method static dumpSpecErrors()
      * @method static void skipRequestValidation()
      */
     class TestResponse

--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -9,12 +9,13 @@ namespace Illuminate\Testing {
     /**
      * @see \Spectator\Assertions
      *
-     * @method self assertValidRequest()
-     * @method self assertInvalidRequest()
-     * @method self assertValidResponse($status = null)
-     * @method self assertInvalidResponse($status = null)
-     * @method self assertValidationMessage($expected)
-     * @method self assertErrorsContain($errors)
+     * @method static assertValidRequest()
+     * @method static assertInvalidRequest()
+     * @method static assertValidResponse($status = null)
+     * @method static assertInvalidResponse($status = null)
+     * @method static assertValidationMessage($expected)
+     * @method static assertErrorsContain($errors)
+     * @method static void skipRequestValidation()
      */
     class TestResponse
     {
@@ -27,12 +28,13 @@ namespace Illuminate\Foundation\Testing {
     /**
      * @see \Spectator\Assertions
      *
-     * @method self assertValidRequest()
-     * @method self assertInvalidRequest()
-     * @method self assertValidResponse($status = null)
-     * @method self assertInvalidResponse($status = null)
-     * @method self assertValidationMessage($expected)
-     * @method self assertErrorsContain($errors)
+     * @method static assertValidRequest()
+     * @method static assertInvalidRequest()
+     * @method static assertValidResponse($status = null)
+     * @method static assertInvalidResponse($status = null)
+     * @method static assertValidationMessage($expected)
+     * @method static assertErrorsContain($errors)
+     * @method static void skipRequestValidation()
      */
     class TestResponse
     {

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -140,6 +140,13 @@ class Assertions
         };
     }
 
+    public function skipRequestValidation()
+    {
+        return function () {
+            Spectator::skipRequestValidation();
+        };
+    }
+
     protected function runAssertion()
     {
         return function (Closure $closure) {

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -5,10 +5,11 @@ namespace Spectator;
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
 use Closure;
-use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Spectator\Concerns\HasExpectations;
 use Spectator\Exceptions\InvalidPathException;
+use Spectator\Exceptions\MalformedSpecException;
 use Spectator\Exceptions\MissingSpecException;
 use Spectator\Exceptions\RequestValidationException;
 use Spectator\Exceptions\ResponseValidationException;
@@ -22,128 +23,134 @@ class Assertions
 
     public function assertValidRequest()
     {
-        return function () {
-            return $this->runAssertion(function () {
-                $contents = $this->getContent() ? $contents = (array) $this->json() : [];
+        return fn () => $this->runAssertion(function () {
+            $exception = app('spectator')->requestException;
 
-                $this->expectsFalse($contents, [
-                    InvalidPathException::class,
-                    MissingSpecException::class,
-                    RequestValidationException::class,
-                    TypeErrorException::class,
-                    UnresolvableReferenceException::class,
-                ]);
+            $this->expectsFalse($exception, [
+                InvalidPathException::class,
+                MalformedSpecException::class,
+                MissingSpecException::class,
+                RequestValidationException::class,
+                TypeErrorException::class,
+                UnresolvableReferenceException::class,
+            ]);
 
-                return $this;
-            });
-        };
+            return $this;
+        });
     }
 
     public function assertInvalidRequest()
     {
-        return function () {
-            return $this->runAssertion(function () {
-                $contents = (array) $this->json();
+        return fn () => $this->runAssertion(function () {
+            $exception = app('spectator')->requestException;
 
-                $this->expectsTrue($contents, [
-                    InvalidPathException::class,
-                    MissingSpecException::class,
-                    RequestValidationException::class,
-                    TypeErrorException::class,
-                    UnresolvableReferenceException::class,
-                ]);
+            $this->expectsTrue($exception, [
+                InvalidPathException::class,
+                MalformedSpecException::class,
+                MissingSpecException::class,
+                RequestValidationException::class,
+                TypeErrorException::class,
+                UnresolvableReferenceException::class,
+            ]);
 
-                return $this;
-            });
-        };
+            return $this;
+        });
     }
 
     public function assertValidResponse()
     {
-        return function ($status = null) {
-            return $this->runAssertion(function () use ($status) {
-                $contents = $this->getContent() ? (array) $this->json() : [];
+        return fn ($status = null) => $this->runAssertion(function () use ($status) {
+            $exception = app('spectator')->responseException;
 
-                $this->expectsFalse($contents, [
-                    ResponseValidationException::class,
-                    TypeErrorException::class,
-                    UnresolvableReferenceException::class,
-                ]);
+            $this->expectsFalse($exception, [
+                ResponseValidationException::class,
+                TypeErrorException::class,
+                UnresolvableReferenceException::class,
+            ]);
 
-                if ($status) {
-                    $actual = $this->getStatusCode();
+            if ($status) {
+                $actual = $this->getStatusCode();
 
-                    PHPUnit::assertTrue(
-                        $actual === $status,
-                        "Expected status code {$status} but received {$actual}."
-                    );
-                }
+                PHPUnit::assertTrue(
+                    $actual === $status,
+                    "Expected status code {$status} but received {$actual}."
+                );
+            }
 
-                return $this;
-            });
-        };
+            return $this;
+        });
     }
 
     public function assertInvalidResponse()
     {
-        return function ($status = null) {
-            return $this->runAssertion(function () use ($status) {
-                $contents = (array) $this->json();
+        return fn ($status = null) => $this->runAssertion(function () use ($status) {
+            $exception = app('spectator')->responseException;
 
-                $this->expectsTrue($contents, [
-                    ResponseValidationException::class,
-                    TypeErrorException::class,
-                    UnresolvableReferenceException::class,
-                ]);
+            $this->expectsTrue($exception, [
+                ResponseValidationException::class,
+                TypeErrorException::class,
+                UnresolvableReferenceException::class,
+            ]);
 
-                if ($status) {
-                    $actual = $this->getStatusCode();
+            if ($status) {
+                $actual = $this->getStatusCode();
 
-                    PHPUnit::assertTrue(
-                        $actual === $status,
-                        "Expected status code {$status} but received {$actual}."
-                    );
-                }
+                PHPUnit::assertTrue(
+                    $actual === $status,
+                    "Expected status code {$status} but received {$actual}."
+                );
+            }
 
-                return $this;
-            });
-        };
+            return $this;
+        });
     }
 
     public function assertValidationMessage()
     {
-        return function ($expected) {
-            return $this->runAssertion(function () use ($expected) {
-                $actual = $this->decodeExceptionMessage((array) $this->json());
+        return fn ($expected) => $this->runAssertion(function () use ($expected) {
+            PHPUnit::assertStringContainsString(
+                $expected,
+                implode(' ', $this->collectExceptionMessages()),
+                'The expected error did not match the actual error.'
+            );
 
-                PHPUnit::assertStringContainsString(
-                    $expected,
-                    $actual,
-                    'The expected error did not match the actual error.'
-                );
-
-                return $this;
-            });
-        };
+            return $this;
+        });
     }
 
     public function assertErrorsContain()
     {
-        return function ($errors) {
-            return $this->runAssertion(function () use ($errors) {
-                self::assertJson([
-                    'specErrors' => Arr::wrap($errors),
-                ]);
+        return fn ($errors) => $this->runAssertion(function () use ($errors) {
+            $matches = 0;
 
-                return $this;
-            });
-        };
+            if (! is_array($errors)) {
+                $errors = [$errors];
+            }
+
+            foreach ($errors as $error) {
+                foreach ($this->collectExceptionMessages() as $message) {
+                    if (Str::contains($message, $error)) {
+                        $matches++;
+                    }
+                }
+            }
+
+            PHPUnit::assertNotSame(
+                0,
+                $matches,
+                'The expected error was not found.'
+            );
+
+            return $this;
+        });
     }
 
-    public function skipRequestValidation()
+    public function dumpSpecErrors()
     {
         return function () {
-            Spectator::skipRequestValidation();
+            dump($this->collectExceptionMessages());
+
+            return $this;
         };
     }
 
@@ -157,6 +164,22 @@ class Assertions
             } catch (\Exception $exception) {
                 throw new \ErrorException($exception->getMessage(), $exception->getCode(), E_WARNING, $original['file'], $original['line']);
             }
+        };
+    }
+
+    protected function collectExceptionMessages()
+    {
+        /*
+         * @return array
+         */
+        return function (): array {
+            $requestException = app('spectator')->requestException;
+            $responseException = app('spectator')->responseException;
+
+            return array_filter([
+                $requestException ? urldecode($requestException->getMessage()) : null,
+                $responseException ? urldecode($responseException->getMessage()) : null,
+            ]);
         };
     }
 }

--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 trait HasExpectations
 {
-    protected $tableStyle;
-
     public function expectsFalse()
     {
         return function ($contents, array $exceptions) {

--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -2,83 +2,50 @@
 
 namespace Spectator\Concerns;
 
-use cebe\openapi\exceptions\TypeErrorException;
-use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableCell;
-use Symfony\Component\Console\Helper\TableCellStyle;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Throwable;
 
 trait HasExpectations
 {
     public function expectsFalse()
     {
-        return function ($contents, array $exceptions) {
-            $exception = $this->exceptionType($contents);
+        /*
+         * @param Throwable|null $throwable
+         * @param array $exceptions
+         * @return void
+         */
+        return function (Throwable $throwable = null, array $exceptions = []) {
+            if ($throwable) {
+                $class = get_class($throwable);
 
-            PHPUnit::assertFalse(
-                in_array($exception, $exceptions),
-                $this->decodeExceptionMessage($contents)
-            );
+                PHPUnit::assertFalse(
+                    in_array($class, $exceptions),
+                    $throwable->getMessage(),
+                );
+            } else {
+                PHPUnit::assertFalse(false);
+            }
         };
     }
 
     public function expectsTrue()
     {
-        return function ($contents, array $exceptions) {
-            $exception = $this->exceptionType($contents);
+        /*
+         * @param Throwable|null $throwable
+         * @param array $exceptions
+         * @return void
+         */
+        return function (Throwable $throwable = null, array $exceptions = []) {
+            if ($throwable) {
+                $class = get_class($throwable);
 
-            PHPUnit::assertTrue(
-                in_array($exception, $exceptions),
-                $this->decodeExceptionMessage($contents)
-            );
-        };
-    }
-
-    public function exceptionType()
-    {
-        return function ($contents) {
-            return Arr::get($contents, 'exception');
-        };
-    }
-
-    protected function decodeExceptionMessage()
-    {
-        return function ($contents) {
-            if (Arr::get($contents, 'exception') === TypeErrorException::class) {
-                return 'The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.';
+                PHPUnit::assertTrue(
+                    in_array($class, $exceptions),
+                    $throwable->getMessage(),
+                );
+            } else {
+                PHPUnit::assertTrue(true);
             }
-
-            $message = trim(Arr::get($contents, 'message', ''));
-
-            if (isset($contents['specErrors']) && count($contents['specErrors']) > 0 && ! config('spectator.suppress_errors')) {
-                $output = new ConsoleOutput();
-
-                $table = new Table($output);
-                $table->setStyle('borderless');
-
-                $table->setHeaders([
-                    new TableCell(
-                        $message,
-                        [
-                            'style' => new TableCellStyle([
-                                'cellFormat' => '<error>%s</error>',
-                            ]),
-                        ],
-                    ),
-                ]);
-
-                $errors = array_filter($contents['specErrors'], fn ($item) => $item !== $message);
-
-                foreach ($errors as $error) {
-                    $table->addRow(["<fg=red>⨯</> <fg=white>{$error}</>"]);
-                }
-
-                $table->render();
-            }
-
-            return $message;
         };
     }
 }

--- a/src/Exceptions/MalformedSpecException.php
+++ b/src/Exceptions/MalformedSpecException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spectator\Exceptions;
+
+class MalformedSpecException extends \Exception
+{
+}

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -41,8 +41,8 @@ class Middleware
     /**
      * Middleware constructor.
      *
-     * @param  RequestFactory  $spectator
-     * @param  ExceptionHandler  $exceptionHandler
+     * @param RequestFactory $spectator
+     * @param ExceptionHandler $exceptionHandler
      */
     public function __construct(RequestFactory $spectator, ExceptionHandler $exceptionHandler)
     {
@@ -51,8 +51,8 @@ class Middleware
     }
 
     /**
-     * @param  Request  $request
-     * @param  Closure  $next
+     * @param Request $request
+     * @param Closure $next
      * @return JsonResponse|Request
      *
      * @throws InvalidPathException
@@ -105,8 +105,8 @@ class Middleware
     }
 
     /**
-     * @param  Request  $request
-     * @param  Closure  $next
+     * @param Request $request
+     * @param Closure $next
      * @return mixed
      *
      * @throws InvalidPathException
@@ -123,11 +123,13 @@ class Middleware
 
         $pathItem = $this->pathItem($request_path, $request->method());
 
-        RequestValidator::validate(
-            $request,
-            $pathItem,
-            $request->method()
-        );
+        if ($this->spectator->shouldValidateRequest()) {
+            RequestValidator::validate(
+                $request,
+                $pathItem,
+                $request->method()
+            );
+        }
 
         $response = $next($request);
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -41,8 +41,8 @@ class Middleware
     /**
      * Middleware constructor.
      *
-     * @param RequestFactory $spectator
-     * @param ExceptionHandler $exceptionHandler
+     * @param  RequestFactory  $spectator
+     * @param  ExceptionHandler  $exceptionHandler
      */
     public function __construct(RequestFactory $spectator, ExceptionHandler $exceptionHandler)
     {
@@ -51,8 +51,8 @@ class Middleware
     }
 
     /**
-     * @param Request $request
-     * @param Closure $next
+     * @param  Request  $request
+     * @param  Closure  $next
      * @return JsonResponse|Request
      *
      * @throws InvalidPathException
@@ -103,8 +103,8 @@ class Middleware
     }
 
     /**
-     * @param Request $request
-     * @param Closure $next
+     * @param  Request  $request
+     * @param  Closure  $next
      * @return mixed
      *
      * @throws InvalidPathException
@@ -180,7 +180,7 @@ class Middleware
     }
 
     /**
-     * @param string $path
+     * @param  string  $path
      * @return string
      */
     protected function resolvePath(string $path): string

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -67,7 +67,7 @@ class Middleware
         }
 
         try {
-            $response = $this->validate($request, $next);
+            return $this->validate($request, $next);
         } catch (InvalidPathException $exception) {
             return $this->formatResponse($exception, 422);
         } catch (RequestValidationException|ResponseValidationException $exception) {
@@ -83,8 +83,6 @@ class Middleware
 
             throw $exception;
         }
-
-        return $response;
     }
 
     /**
@@ -115,7 +113,7 @@ class Middleware
      * @throws TypeErrorException
      * @throws UnresolvableReferenceException
      * @throws IOException
-     * @throws InvalidJsonPointerSyntaxException
+     * @throws InvalidJsonPointerSyntaxException|Exceptions\SchemaValidationException
      */
     protected function validate(Request $request, Closure $next)
     {
@@ -139,8 +137,6 @@ class Middleware
             $pathItem->{strtolower($request->method())},
             $this->version
         );
-
-        $this->spectator->reset();
 
         return $response;
     }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -40,8 +40,8 @@ class Middleware
     /**
      * Middleware constructor.
      *
-     * @param RequestFactory $spectator
-     * @param ExceptionHandler $exceptionHandler
+     * @param  RequestFactory  $spectator
+     * @param  ExceptionHandler  $exceptionHandler
      */
     public function __construct(RequestFactory $spectator, ExceptionHandler $exceptionHandler)
     {
@@ -50,8 +50,8 @@ class Middleware
     }
 
     /**
-     * @param Request $request
-     * @param Closure $next
+     * @param  Request  $request
+     * @param  Closure  $next
      * @return JsonResponse|Request
      *
      * @throws InvalidPathException
@@ -98,8 +98,8 @@ class Middleware
     }
 
     /**
-     * @param Request $request
-     * @param Closure $next
+     * @param  Request  $request
+     * @param  Closure  $next
      * @return mixed
      *
      * @throws InvalidPathException
@@ -182,7 +182,7 @@ class Middleware
     }
 
     /**
-     * @param string $path
+     * @param  string  $path
      * @return string
      */
     protected function resolvePath(string $path): string

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -23,10 +23,19 @@ use Spectator\Validation\ResponseValidator;
 
 class Middleware
 {
+    /**
+     * @var ExceptionHandler
+     */
     protected ExceptionHandler $exceptionHandler;
 
+    /**
+     * @var RequestFactory
+     */
     protected RequestFactory $spectator;
 
+    /**
+     * @var string
+     */
     protected string $version = '3.0';
 
     /**
@@ -172,6 +181,10 @@ class Middleware
         throw new InvalidPathException("Path [{$request_method} {$request_path}] not found in spec.", 404);
     }
 
+    /**
+     * @param string $path
+     * @return string
+     */
     protected function resolvePath(string $path): string
     {
         $separator = '/';

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -11,17 +11,26 @@ use Spectator\Exceptions\MissingSpecException;
 
 class RequestFactory
 {
-    /*
-     * @method static void assertValidRequest()
-     */
     use Macroable;
 
+    /**
+     * @var string|null
+     */
     protected ?string $specName = null;
 
+    /**
+     * @var string|null
+     */
     protected ?string $pathPrefix = null;
 
+    /**
+     * @var bool
+     */
     protected bool $validateRequest = true;
 
+    /**
+     * @var array
+     */
     private array $cachedSpecs = [];
 
     /**
@@ -72,11 +81,9 @@ class RequestFactory
      *
      * return RequestFactory
      */
-    public function reset(): self
+    public function reset(): void
     {
         $this->specName = null;
-
-        return $this;
     }
 
     /**
@@ -110,6 +117,7 @@ class RequestFactory
     {
         if ($this->specName) {
             $file = $this->getFile();
+
             if ($this->cachedSpecs[$file] ?? null) {
                 return $this->cachedSpecs[$file];
             }
@@ -153,7 +161,7 @@ class RequestFactory
     /**
      * Retrieve a local spec file.
      *
-     * @param  array  $source
+     * @param array $source
      * @param $file
      * @return string
      *
@@ -175,7 +183,7 @@ class RequestFactory
     /**
      * Retrieve a remote spec file.
      *
-     * @param  array  $source
+     * @param array $source
      * @param $file
      * @return string
      */
@@ -193,7 +201,7 @@ class RequestFactory
     /**
      * Build a Github path.
      *
-     * @param  array  $source
+     * @param array $source
      * @param $file
      * @return string
      */

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -161,7 +161,7 @@ class RequestFactory
     /**
      * Retrieve a local spec file.
      *
-     * @param array $source
+     * @param  array  $source
      * @param $file
      * @return string
      *
@@ -183,7 +183,7 @@ class RequestFactory
     /**
      * Retrieve a remote spec file.
      *
-     * @param array $source
+     * @param  array  $source
      * @param $file
      * @return string
      */
@@ -201,7 +201,7 @@ class RequestFactory
     /**
      * Build a Github path.
      *
-     * @param array $source
+     * @param  array  $source
      * @param $file
      * @return string
      */

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -137,7 +137,7 @@ class RequestFactory
     }
 
     /**
-     * @param Throwable $throwable
+     * @param  Throwable  $throwable
      * @return void
      */
     public function captureRequestValidation(Throwable $throwable)
@@ -146,7 +146,7 @@ class RequestFactory
     }
 
     /**
-     * @param Throwable $throwable
+     * @param  Throwable  $throwable
      * @return void
      */
     public function captureResponseValidation(Throwable $throwable)

--- a/src/Spectator.php
+++ b/src/Spectator.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getPathPrefix() Get the path prefix being used.
  * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used.
  * @method static object resolve() Resolve the spec into an object.
- * @method static void skipRequestValidation() Disable request validation.
  * @method bool shouldValidateRequest() Indicate if request should be validated.
  *
  * @see \Spectator\RequestFactory
@@ -25,7 +24,6 @@ class Spectator extends Facade
      * @method static string getPathPrefix() Get the path prefix being used.
      * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used.
      * @method static object resolve() Resolve the spec into an object.
-     * @method static void skipRequestValidation() Disable request validation.
      * @method bool shouldValidateRequest() Indicate if request should be validated.
      *
      * @see \Spectator\RequestFactory

--- a/src/Spectator.php
+++ b/src/Spectator.php
@@ -5,28 +5,28 @@ namespace Spectator;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void using($name) Set the spec file to use
- * @method static void reset() Reset the Spectator instance
- * @method static string getSpec() Get the spec being used
- * @method static string getPathPrefix() Get the path prefix being used
- * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used
- * @method static object resolve() Resolve the spec into an object
- * @method static void skipRequestValidation() Disable request validation
- * @method bool shouldValidateRequest() Indicate if request should be validated
+ * @method static void using($name) Set the spec file to use.
+ * @method static void reset() Reset the name of the spec.
+ * @method static string getSpec() Get the spec being used.
+ * @method static string getPathPrefix() Get the path prefix being used.
+ * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used.
+ * @method static object resolve() Resolve the spec into an object.
+ * @method static void skipRequestValidation() Disable request validation.
+ * @method bool shouldValidateRequest() Indicate if request should be validated.
  *
  * @see \Spectator\RequestFactory
  */
 class Spectator extends Facade
 {
     /**
-     * @method static void using($name) Set the spec file to use
-     * @method static void reset() Reset the Spectator instance
-     * @method static string getSpec() Get the spec being used
-     * @method static string getPathPrefix() Get the path prefix being used
-     * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used
-     * @method static object resolve() Resolve the spec into an object
-     * @method static void skipRequestValidation() Disable request validation
-     * @method bool shouldValidateRequest() Indicate if request should be validated
+     * @method static void using($name) Set the spec file to use.
+     * @method static void reset() Reset the name of the spec.
+     * @method static string getSpec() Get the spec being used.
+     * @method static string getPathPrefix() Get the path prefix being used.
+     * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used.
+     * @method static object resolve() Resolve the spec into an object.
+     * @method static void skipRequestValidation() Disable request validation.
+     * @method bool shouldValidateRequest() Indicate if request should be validated.
      *
      * @see \Spectator\RequestFactory
      */

--- a/src/Spectator.php
+++ b/src/Spectator.php
@@ -5,24 +5,28 @@ namespace Spectator;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void using($name): void
- * @method static void reset(): void
- * @method static string getSpec(): string
- * @method static string getPathPrefix(): string
- * @method static RequestFactory setPathPrefix($prefix): RequestFactory
- * @method static object resolve(): SpecObjectInterface
+ * @method static void using($name) Set the spec file to use
+ * @method static void reset() Reset the Spectator instance
+ * @method static string getSpec() Get the spec being used
+ * @method static string getPathPrefix() Get the path prefix being used
+ * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used
+ * @method static object resolve() Resolve the spec into an object
+ * @method static void skipRequestValidation() Disable request validation
+ * @method bool shouldValidateRequest() Indicate if request should be validated
  *
  * @see \Spectator\RequestFactory
  */
 class Spectator extends Facade
 {
     /**
-     * @method static void using($name): void
-     * @method static void reset(): void
-     * @method static string getSpec(): string|null
-     * @method static string getPathPrefix(): string
-     * @method static RequestFactory setPathPrefix($prefix): RequestFactory
-     * @method static object resolve(): SpecObjectInterface
+     * @method static void using($name) Set the spec file to use
+     * @method static void reset() Reset the Spectator instance
+     * @method static string getSpec() Get the spec being used
+     * @method static string getPathPrefix() Get the path prefix being used
+     * @method static RequestFactory setPathPrefix($prefix) Set the path prefix being used
+     * @method static object resolve() Resolve the spec into an object
+     * @method static void skipRequestValidation() Disable request validation
+     * @method bool shouldValidateRequest() Indicate if request should be validated
      *
      * @see \Spectator\RequestFactory
      */

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -23,6 +23,7 @@ class SpectatorServiceProvider extends ServiceProvider
         $this->mergeConfig();
 
         $this->app->singleton(RequestFactory::class);
+        $this->app->alias(RequestFactory::class, 'spectator');
     }
 
     protected function mergeConfig()

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -637,7 +637,7 @@ class RequestValidatorTest extends TestCase
             ->assertValidResponse();
 
         $this->getJson('/posts/invalid')
-            ->assertValidRequest()
+            ->assertInvalidRequest()
             ->assertValidResponse();
 
         Spectator::skipRequestValidation();

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -616,6 +616,40 @@ class RequestValidatorTest extends TestCase
             [['name' => 'dog', 'friend' => ['name' => 'Alice', 'age' => null]], true],
         ];
     }
+
+    public function test_skip_request_validation(): void
+    {
+        Spectator::using('Test.v1.json');
+
+        Route::bind('postUuid', TestUser::class);
+
+        $uuid = Str::uuid();
+
+        Route::get('/posts/{postUuid}', function () {
+            return [
+                'id' => 1,
+                'title' => 'My Post',
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson("/posts/{$uuid}")
+            ->assertValidRequest()
+            ->assertValidResponse();
+
+        $this->getJson('/posts/invalid')
+            ->assertValidRequest()
+            ->assertValidResponse();
+
+        Spectator::skipRequestValidation();
+
+        $this->getJson("/posts/{$uuid}")
+            ->assertValidRequest()
+            ->assertValidResponse();
+
+        $this->getJson('/posts/invalid')
+            ->assertValidRequest()
+            ->assertValidResponse();
+    }
 }
 
 class TestUser extends Model

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -487,14 +487,22 @@ class RequestValidatorTest extends TestCase
             return [];
         })->middleware(Middleware::class);
 
-        $this->getJson('/users?order=invalid')
-            ->assertInvalidRequest()
-            ->assertErrorsContain([
-                'The data should match one item from enum',
-            ]);
+        $this->get('/users?order=invalid')
+            ->assertValidationMessage('The data should match one item from enum')
+            ->assertInvalidRequest();
 
-        $this->getJson('/users?order=name')
+        $this->get('/users?order=')
             ->assertValidRequest();
+
+        $this->get('/users?order=name')
+            ->assertValidRequest();
+
+        $this->get('/users?order=email')
+            ->assertValidRequest();
+
+        $this->get('/users?order=email,name')
+            ->assertValidationMessage('The data should match one item from enum')
+            ->assertInvalidRequest();
     }
 
     public function test_handles_query_parameters_int(): void
@@ -617,7 +625,7 @@ class RequestValidatorTest extends TestCase
         ];
     }
 
-    public function test_skip_request_validation(): void
+    public function test_ignores_request_validation_if_not_asserted(): void
     {
         Spectator::using('Test.v1.json');
 
@@ -640,14 +648,10 @@ class RequestValidatorTest extends TestCase
             ->assertInvalidRequest()
             ->assertValidResponse();
 
-        Spectator::skipRequestValidation();
-
         $this->getJson("/posts/{$uuid}")
-            ->assertValidRequest()
             ->assertValidResponse();
 
         $this->getJson('/posts/invalid')
-            ->assertValidRequest()
             ->assertValidResponse();
     }
 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -35,7 +35,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson('/users')
             ->assertValidRequest()
-            ->assertValidResponse(200);
+            ->assertValidResponse();
     }
 
     public function test_validates_invalid_json_response(): void
@@ -50,7 +50,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson('/users')
             ->assertValidRequest()
-            ->assertInvalidResponse(400)
+            ->assertInvalidResponse()
             ->assertValidationMessage('All array items must match schema');
 
         Route::get('/users', static function () {
@@ -64,7 +64,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson('/users')
             ->assertValidRequest()
-            ->assertInvalidResponse(400)
+            ->assertInvalidResponse()
             ->assertValidationMessage('All array items must match schema');
     }
 
@@ -80,7 +80,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson('/path-without-operationId')
             ->assertValidRequest()
-            ->assertInvalidResponse(400);
+            ->assertInvalidResponse();
     }
 
     public function test_cannot_locate_path_without_path_prefix(): void
@@ -105,7 +105,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson('/api/v2/users')
             ->assertValidRequest()
-            ->assertValidResponse(200);
+            ->assertValidResponse();
     }
 
     public function test_uncaught_exceptions_are_thrown_when_exception_handling_is_disabled(): void
@@ -536,7 +536,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson('/users')
             ->assertValidRequest()
-            ->assertInvalidResponse(400)
+            ->assertInvalidResponse()
             ->assertValidationMessage('All array items must match schema')
             ->assertErrorsContain([
                 'All array items must match schema',
@@ -561,7 +561,7 @@ class ResponseValidatorTest extends TestCase
 
         $this->getJson("/orgs/$uuid")
             ->assertValidRequest()
-            ->assertValidResponse(200);
+            ->assertValidResponse();
     }
 
     public function test_response_fails_with_invalid_array(): void


### PR DESCRIPTION
This change updates Spectator so that only validation that is specified is run. 

For example, this will only run request validation and not response validation:
```php
$this->getJson("/users")
    ->assertValidRequest();
```
Previously, if the response was invalid it would have thrown an error, but with the update this is no longer the case.