### PR TITLE
Requests are processed twice

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -61,20 +61,20 @@ class Middleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $response = $next($request);
+        if (!$this->spectator->getSpec()) {
+            return $next($request);
+        }
 
-        if ($this->spectator->getSpec()) {
-            try {
-                $response = $this->validate($request, $next);
-            } catch (InvalidPathException|MalformedSpecException|MissingSpecException|TypeErrorException|UnresolvableReferenceException $exception) {
-                $this->spectator->captureRequestValidation($exception);
-            } catch (\Throwable $exception) {
-                if ($this->exceptionHandler->shouldReport($exception)) {
-                    return $this->formatResponse($exception, 500);
-                }
-
-                throw $exception;
+        try {
+            $response = $this->validate($request, $next);
+        } catch (InvalidPathException|MalformedSpecException|MissingSpecException|TypeErrorException|UnresolvableReferenceException $exception) {
+            $this->spectator->captureRequestValidation($exception);
+        } catch (\Throwable $exception) {
+            if ($this->exceptionHandler->shouldReport($exception)) {
+                return $this->formatResponse($exception, 500);
             }
+
+            throw $exception;
         }
 
         return $response;

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spectator\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Spectator\Middleware;
+use Spectator\Spectator;
+use Spectator\SpectatorServiceProvider;
+
+class MiddlewareTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->register(SpectatorServiceProvider::class);
+
+        Spectator::using('Test.v1.json');
+    }
+
+    public function test_only_processes_request_once(): void
+    {
+        $numberOfTimesProcessed = 0;
+
+        Route::get('/users', static function () use (&$numberOfTimesProcessed) {
+            $numberOfTimesProcessed++;
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/users');
+
+        static::assertEquals(1, $numberOfTimesProcessed);
+    }
+}


### PR DESCRIPTION
## Description
A bug was introduced in #110 which results in requests being processed twice if a spec file is set.

This happens because the early return was removed, and we subsequently call `$next($request)` twice in the middleware: once at the top of the `handle()` method; and once within the `validate()` method. 

The "correct" code isn't easy on the eye—which may be why the change was made in the first place—but it gets the job done. 

I've included a pretty crude test that demonstrates the issue. I wasn't too sure where to stick it, so if you want it to go somewhere else, let me know.