### PR TITLE
Fix #118 middleware processes request twice.

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -61,11 +61,9 @@ class Middleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $response = $next($request);
-
         if ($this->spectator->getSpec()) {
             try {
-                $response = $this->validate($request, $next);
+                return $this->validate($request, $next);
             } catch (InvalidPathException|MalformedSpecException|MissingSpecException|TypeErrorException|UnresolvableReferenceException $exception) {
                 $this->spectator->captureRequestValidation($exception);
             } catch (\Throwable $exception) {
@@ -75,9 +73,9 @@ class Middleware
 
                 throw $exception;
             }
+        } else {
+            return $next($request);
         }
-
-        return $response;
     }
 
     /**


### PR DESCRIPTION
Middleware looks like processing request twice.
Fix it moving first request under the if clause.

I thought that I should write the test, but I have no idea how to write a test for this.