### PR TITLE
Handle validation of nested query parameters e.g. ?filter[groupId]=

### DIFF
--- a/tests/Fixtures/Test.v1.json
+++ b/tests/Fixtures/Test.v1.json
@@ -378,7 +378,7 @@
       ],
       "get": {
         "summary": "Get Order",
-        "description": "Orders are made by organizations to fund tree planting, and when trees are planted those orders will be marked as fullfilled. Orders may be partially fulfilled, and it is up to you if you wish to import those. Make sure to deduplicate the trees if you do.",
+        "description": "Orders are made by organizations to fund tree planting, and when trees are planted those orders will be marked as fulfilled. Orders may be partially fulfilled, and it is up to you if you wish to import those. Make sure to deduplicate the trees if you do.",
         "tags": [],
         "responses": {
           "200": {
@@ -413,6 +413,48 @@
           }
         },
         "operationId": "get-orders-uuid"
+      }
+    },
+    "/orders": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "example": "53f7bd7b-2ee2-4be4-a15b-e09c76a150f9"
+          },
+          "name": "filter[groupId]",
+          "in": "query",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "Filter Orders",
+        "description": "Orders are made by organizations to fund tree planting, and when trees are planted those orders will be marked as fulfilled. Orders may be partially fulfilled, and it is up to you if you wish to import those. Make sure to deduplicate the trees if you do.",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Generic_Problem"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "filter-orders-by-group"
       }
     }
   },

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -503,6 +503,22 @@ class RequestValidatorTest extends TestCase
         $this->get('/users?order=email,name')
             ->assertValidationMessage('The data should match one item from enum')
             ->assertInvalidRequest();
+
+        // Test it handles nested query parameters
+        Route::get('/orders', function () {
+            return [];
+        })->middleware(Middleware::class);
+
+        $this->get('/orders')
+            ->assertValidationMessage('Missing required query parameter [?filter[groupId]=].')
+            ->assertInvalidRequest();
+
+        $this->get('/orders?filter[groupId]=1')
+            ->assertValidationMessage('The data must match the \'uuid\' format')
+            ->assertInvalidRequest();
+
+        $this->get('/orders?filter[groupId]=cc8936c7-d681-4c42-9410-c50488f43736')
+            ->assertValid();
     }
 
     public function test_handles_query_parameters_int(): void


### PR DESCRIPTION
Nested query parameters such as `?filter[groupId]` always return null during the validation. 

This is due to `$this->request->query->has` being a pretty simple Symfony implementation (as documented https://github.com/laravel/framework/issues/33376) 

This adds some support to getting these nested query parameters in the recommended way from the query string. 

Fixes #130 