### PR TITLE
Allow comma separated values in the query parameters

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -121,7 +121,7 @@ class RequestValidator extends AbstractValidator
                 } elseif ($parameter->in === 'query' && $this->hasQueryParam($parameter->name)) {
                     $parameter_value = $this->getQueryParam($parameter->name);
 
-                    if ($parameter->explode === false) {
+                    if ($parameter->explode === false && $parameter->schema->type === 'array') {
                         $parameter_value = explode(',', $parameter_value);
                     }
                 } elseif ($parameter->in === 'header' && $this->request->headers->has($parameter->name)) {

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -120,6 +120,10 @@ class RequestValidator extends AbstractValidator
                     }
                 } elseif ($parameter->in === 'query' && $this->hasQueryParam($parameter->name)) {
                     $parameter_value = $this->getQueryParam($parameter->name);
+
+                    if ($parameter->explode === false) {
+                        $parameter_value = explode(',', $parameter_value);
+                    }
                 } elseif ($parameter->in === 'header' && $this->request->headers->has($parameter->name)) {
                     $parameter_value = $this->request->headers->get($parameter->name);
                 } elseif ($parameter->in === 'cookie' && $this->request->cookies->has($parameter->name)) {

--- a/tests/Fixtures/CommaSeparatedString.v1.json
+++ b/tests/Fixtures/CommaSeparatedString.v1.json
@@ -1,0 +1,126 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Numbers.v1",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number",
+                        "description": "User ID",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "User name",
+                        "example": "Adam Campbell"
+                      },
+                      "email": {
+                        "type": "string",
+                        "description": "User email address",
+                        "format": "email",
+                        "example": "test@test.com"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "example-1": {
+                    "value": [
+                      {
+                        "id": 1,
+                        "name": "Adam Campbell",
+                        "email": "test@test.com"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number",
+                        "description": "User ID",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "User name",
+                        "example": "Adam Campbell"
+                      },
+                      "email": {
+                        "type": "string",
+                        "description": "User email address",
+                        "format": "email",
+                        "example": "test@test.com"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "example-1": {
+                    "value": [
+                      {
+                        "id": 1,
+                        "name": "Adam Campbell",
+                        "email": "test@test.com"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-users",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "",
+            "example": "foo,bar",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["foo", "bar"]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -656,6 +656,27 @@ class RequestValidatorTest extends TestCase
             ->assertValidResponse();
     }
 
+    public function test_comma_separated_values()
+    {
+        Spectator::using('CommaSeparatedString.v1.json');
+
+        Route::get('/users', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })
+            ->middleware(Middleware::class);
+
+        $this->getJson('/users?include=foo,bar')
+            ->assertStatus(200)
+            ->assertValidRequest()
+            ->assertValidResponse();
+    }
+
     public function nullableObjectProvider(): array
     {
         return [


### PR DESCRIPTION
Wasn't able to assert for valid comma separated values in query parameters e.g. `?include=foo,bar` as the value passed to the JSON schema package was still a string and not exploded.

When looking online about how people define comma separated values in query params this StackOverflow seems to be the agreed way (https://stackoverflow.com/a/66829618).

This PR just adds a little piece of logic to explode the value by comma if the property `explode` is false in the parameter. 