### PR TITLE
Add assertPathExists assertion

### DIFF
--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -145,6 +145,19 @@ class Assertions
         });
     }
 
+    public function assertPathExists()
+    {
+        return fn () => $this->runAssertion(function () {
+            $exception = app('spectator')->requestException;
+
+            $this->expectsFalse($exception, [
+                InvalidPathException::class,
+            ]);
+
+            return $this;
+        });
+    }
+
     public function dumpSpecErrors()
     {
         return function () {

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -73,4 +73,24 @@ class AssertionsTest extends TestCase
             ->assertValidRequest()
             ->assertValidResponse(422);
     }
+
+    public function test_asserts_path_exists()
+    {
+        Route::get('/users')->middleware(Middleware::class);
+
+        $this->getJson('/users')
+            ->assertPathExists();
+    }
+
+    public function test_asserts_path_does_not_exist()
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Path [GET /invalid] not found in spec.');
+
+        Route::get('/invalid')->middleware(Middleware::class);
+
+        $this->getJson('/invalid')
+            ->assertPathExists();
+    }
 }


### PR DESCRIPTION
This assertion is a convenient way to only check whether an endpoint is in the spec or not.

Concrete use case in one of my projects:
Iteration over all endpoints in API and check for every one of them whether they are present in the specification.
When adding these tests in the CI pipeline I can make sure that new endpoints also find their way into the specification.

Why can't I just use `assertInvalidRequest`?
Because when automatically iterating over endpoints I don't have request bodies to append and so the assertion complains about this first. I just want to know about the `InvalidPathException`.

Hope this finds the way into the codebase, otherwise I would have to find a way to extend the package.