### PR TITLE
Add ability to choose which groups the middleware should be prepended to

### DIFF
--- a/config/spectator.php
+++ b/config/spectator.php
@@ -65,4 +65,15 @@ return [
     */
 
     'suppress_errors' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Middleware Groups
+    |--------------------------------------------------------------------------
+    |
+    | Specify the groups that spectator's middleware should be prepended to.
+    |
+    */
+
+    'middleware_groups' => ['api'],
 ];

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -28,7 +28,7 @@ class SpectatorServiceProvider extends ServiceProvider
 
     protected function mergeConfig()
     {
-        $configPath = __DIR__ . '/../config/spectator.php';
+        $configPath = __DIR__.'/../config/spectator.php';
 
         $this->mergeConfigFrom($configPath, 'spectator');
     }
@@ -54,7 +54,7 @@ class SpectatorServiceProvider extends ServiceProvider
 
     protected function publishConfig()
     {
-        $configPath = __DIR__ . '/../config/spectator.php';
+        $configPath = __DIR__.'/../config/spectator.php';
 
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
     }

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -28,14 +28,18 @@ class SpectatorServiceProvider extends ServiceProvider
 
     protected function mergeConfig()
     {
-        $configPath = __DIR__.'/../config/spectator.php';
+        $configPath = __DIR__ . '/../config/spectator.php';
 
         $this->mergeConfigFrom($configPath, 'spectator');
     }
 
     protected function registerMiddleware()
     {
-        $this->app[Kernel::class]->prependMiddlewareToGroup('api', Middleware::class);
+        $groups = config('spectator.middleware_groups');
+
+        foreach ($groups as $group) {
+            $this->app[Kernel::class]->prependMiddlewareToGroup($group, Middleware::class);
+        }
     }
 
     protected function decorateTestResponse()
@@ -50,7 +54,7 @@ class SpectatorServiceProvider extends ServiceProvider
 
     protected function publishConfig()
     {
-        $configPath = __DIR__.'/../config/spectator.php';
+        $configPath = __DIR__ . '/../config/spectator.php';
 
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
     }


### PR DESCRIPTION
In our company's case, not all endpoints are under the api group. We would like to be able to change which group the middleware should be prepended to.