### PR TITLE
Fix undefined variable middleware

### DIFF
--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Spectator\Tests;
 
+use ErrorException;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\ValidationException;
@@ -35,6 +36,46 @@ class AssertionsTest extends TestCase
         $this->getJson('/invalid')
             ->assertInvalidRequest()
             ->assertValidationMessage('Path [GET /invalid] not found in spec.');
+    }
+
+    public function test_fails_asserts_invalid_path()
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Path [GET /invalid] not found in spec.');
+
+        Route::get('/invalid', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/invalid')
+            ->assertValidRequest();
+    }
+
+    public function test_fails_asserts_invalid_path_without_exception_handling()
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Path [GET /invalid] not found in spec.');
+
+        Route::get('/invalid', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->withoutExceptionHandling();
+
+        $this->getJson('/invalid')
+            ->assertValidRequest();
     }
 
     public function test_exception_points_to_mixin_method()


### PR DESCRIPTION
I fucked up with git, original PR (#137) was closed :facepalm: 

This PR fixes https://github.com/hotmeteor/spectator/issues/136

Problem comes from the fact that in the test suite, we are using Laravel's exception handler wich will hide some issues. If in their projet the developer uses withoutExceptionHandling, they can face Spectator bug (in this case returning an undefined variable).

I decided to fix this issue extracting PathItem resolution from actual request/response validation.

I would also suggest to run the entire test suite without exception handling (except required ones like ValidationException or HttpException) in order to prevent such issues to be hidden again. I can send a follow-up PR if you want.

Finally, not sur if this PR should be sent to master or develop branch. @hotmeteor please tell me if I should send it to develop, I will rebase my branch and change that