### PR TITLE
Fixing AnyOf within arrays that is inside an object

### DIFF
--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -68,6 +68,11 @@ class Assertions
                 UnresolvableReferenceException::class,
             ]);
 
+            // If there's an issue with spectator throw so we don't have hidden exceptions.
+            if ($exception && strpos($exception->getTrace()[1]['file'], 'spectator/src') !== false) {
+                throw $exception;
+            }
+
             if ($status) {
                 $actual = $this->getStatusCode();
 

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -119,6 +119,10 @@ class RequestValidator extends AbstractValidator
                     }
                 } elseif ($parameter->in === 'query' && $this->hasQueryParam($parameter->name)) {
                     $parameter_value = $this->getQueryParam($parameter->name);
+
+                    if ($parameter->explode === false && $parameter->schema->type === 'array') {
+                        $parameter_value = explode(',', $parameter_value);
+                    }
                 } elseif ($parameter->in === 'header' && $this->request->headers->has($parameter->name)) {
                     $parameter_value = $this->request->headers->get($parameter->name);
                 } elseif ($parameter->in === 'cookie' && $this->request->cookies->has($parameter->name)) {

--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -57,7 +57,7 @@ class ResponseValidator extends AbstractValidator
         // This is a bit hacky, but will allow resolving other JSON responses like application/problem+json
         // when returning standard JSON responses from frameworks (See hotmeteor/spectator#114)
 
-        $specTypes = array_values(array_map(
+        $specTypes = array_combine(array_keys($response->content), array_map(
             fn ($type) => $contentType === 'application/json' && Str::endsWith($type, '+json') ? 'application/json' : $type,
             array_keys($response->content)
         ));
@@ -71,6 +71,9 @@ class ResponseValidator extends AbstractValidator
 
             throw new ResponseValidationException($message);
         }
+
+        // Lookup the content type specified in the spec that match the application/json content type
+        $contentType = array_flip($specTypes)[$contentType];
 
         $schema = $response->content[$contentType]->schema;
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Spectator\Tests;
 
+use ErrorException;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\ValidationException;
@@ -35,6 +36,46 @@ class AssertionsTest extends TestCase
         $this->getJson('/invalid')
             ->assertInvalidRequest()
             ->assertValidationMessage('Path [GET /invalid] not found in spec.');
+    }
+
+    public function test_fails_asserts_invalid_path()
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Path [GET /invalid] not found in spec.');
+
+        Route::get('/invalid', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/invalid')
+            ->assertValidRequest();
+    }
+
+    public function test_fails_asserts_invalid_path_without_exception_handling()
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Path [GET /invalid] not found in spec.');
+
+        Route::get('/invalid', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->withoutExceptionHandling();
+
+        $this->getJson('/invalid')
+            ->assertValidRequest();
     }
 
     public function test_exception_points_to_mixin_method()

--- a/tests/Fixtures/ArrayAnyOf.v1.yml
+++ b/tests/Fixtures/ArrayAnyOf.v1.yml
@@ -13,11 +13,14 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  anyOf:
-                    - $ref: '#/components/schemas/PetByAge'
-                    - $ref: '#/components/schemas/PetByType'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/PetByAge'
+                        - $ref: '#/components/schemas/PetByType'
 components:
   schemas:
     PetByAge:

--- a/tests/Fixtures/CommaSeparatedString.v1.json
+++ b/tests/Fixtures/CommaSeparatedString.v1.json
@@ -1,0 +1,126 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Numbers.v1",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number",
+                        "description": "User ID",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "User name",
+                        "example": "Adam Campbell"
+                      },
+                      "email": {
+                        "type": "string",
+                        "description": "User email address",
+                        "format": "email",
+                        "example": "test@test.com"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "example-1": {
+                    "value": [
+                      {
+                        "id": 1,
+                        "name": "Adam Campbell",
+                        "email": "test@test.com"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number",
+                        "description": "User ID",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "User name",
+                        "example": "Adam Campbell"
+                      },
+                      "email": {
+                        "type": "string",
+                        "description": "User email address",
+                        "format": "email",
+                        "example": "test@test.com"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "example-1": {
+                    "value": [
+                      {
+                        "id": 1,
+                        "name": "Adam Campbell",
+                        "email": "test@test.com"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-users",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "",
+            "example": "foo,bar",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["foo", "bar"]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -656,6 +656,27 @@ class RequestValidatorTest extends TestCase
             ->assertValidResponse();
     }
 
+    public function test_comma_separated_values()
+    {
+        Spectator::using('CommaSeparatedString.v1.json');
+
+        Route::get('/users', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })
+            ->middleware(Middleware::class);
+
+        $this->getJson('/users?include=foo,bar')
+            ->assertStatus(200)
+            ->assertValidRequest()
+            ->assertValidResponse();
+    }
+
     public function nullableObjectProvider(): array
     {
         return [

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -669,7 +669,7 @@ class ResponseValidatorTest extends TestCase
                     ['age' => 5, 'nickname' => 'nick'],
                     // PetByType
                     ['pet_type' => 'Dog', 'hunts' => false],
-                ]
+                ],
             ];
         })->middleware(Middleware::class);
 

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -660,19 +660,21 @@ class ResponseValidatorTest extends TestCase
 
     public function test_array_any_of(): void
     {
-        Spectator::using('ArrayAnyOf.v1.yaml');
+        Spectator::using('ArrayAnyOf.v1.yml');
 
-        Route::patch('/pets', static function () {
+        Route::get('/pets', static function () {
             return [
-                // PetByAge
-                ['age' => 5, 'nickname' => 'nick'],
-                // PetByType
-                ['pet_type' => 'Dog', 'hunts' => false],
+                'data' => [
+                    // PetByAge
+                    ['age' => 5, 'nickname' => 'nick'],
+                    // PetByType
+                    ['pet_type' => 'Dog', 'hunts' => false],
+                ]
             ];
         })->middleware(Middleware::class);
 
         $response = $this->getJson('/pets');
-        $response->assertValidResponse();
+        $response->assertValidRequest()->assertValidResponse();
     }
 
     /**


### PR DESCRIPTION
While trying to test a AnyOf within an array which was in an object we hit an issue with the filtering for readonly and writeonly that caused an exception to be thrown. However this exception was suppressed because spectator only throws certain types of exceptions.

So this PR fixes:
- The original AnyOf issue
- Enabling an exception to bubble up if it has come from an internal error within Spectator
- A test that was failing now that we are bubbling up the error.