### PR TITLE
Run tests on Laravel 10 and PHP 8.2/8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,16 +13,28 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: [ 8.*, 9.* ]
-        php: [ 7.4, 8.0, 8.1 ]
+        laravel: [ 8.*, 9.*, 10.* ]
+        php: [ 7.4, 8.0, 8.1, 8.2, 8.3 ]
         include:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
         exclude:
+          - laravel: 8.*
+            php: 8.2
+          - laravel: 8.*
+            php: 8.3
           - laravel: 9.*
             php: 7.4
+          - laravel: 9.*
+            php: 8.3
+          - laravel: 10.*
+            php: 7.4
+          - laravel: 10.*
+            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 


### PR DESCRIPTION
This PR adds test execution for supported version of Laravel and PHP