### PR TITLE
Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: [ 10.* ]
+        laravel: [ 10.*, 11.* ]
         php: [ 8.1, 8.2, 8.3 ]
-        phpunit: [ 10.* ]
+        phpunit: [ 10.*, 11.* ]
         include:
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
+        exclude:
+          - laravel: 10.*
+            phpunit: 11.*
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - PU${{ matrix.phpunit }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": "^8.1",
     "ext-json": "*",
-    "cebe/php-openapi": "^1.7",
+    "devizzent/cebe-php-openapi": "^1.0",
     "laravel/framework": "^10.0 | ^11.0",
     "opis/json-schema": "^2.3"
   },
@@ -51,5 +51,6 @@
   "config": {
     "sort-packages": true
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     "php": "^8.1",
     "ext-json": "*",
     "cebe/php-openapi": "^1.7",
-    "laravel/framework": "^10.0",
+    "laravel/framework": "^10.0 | ^11.0",
     "opis/json-schema": "^2.3"
   },
   "require-dev": {
     "laravel/pint": "^1.13",
-    "nunomaduro/collision": "^7.0",
-    "orchestra/testbench": "^8.0",
-    "phpunit/phpunit": "^10.0"
+    "nunomaduro/collision": "^7.0|^8.0",
+    "orchestra/testbench": "^8.0|^9.0",
+    "phpunit/phpunit": "^10.0|^11.0"
   },
   "autoload": {
     "psr-4": {
@@ -50,5 +50,6 @@
   },
   "config": {
     "sort-packages": true
-  }
+  },
+  "minimum-stability": "dev"
 }


### PR DESCRIPTION
Add Laravel 11 support

~Currently stuck as https://github.com/cebe/php-openapi does not support Symfony 7 yet~

cebe/php-openapi is currently inactive and an active fork appeared with Symfony 7 support : [DEVizzent/cebe-php-openapi](https://github.com/DEVizzent/cebe-php-openapi)
It is used by [thephpleague/openapi-psr7-validator](https://github.com/thephpleague/openapi-psr7-validator/blob/master/composer.json) and is a drop-in replacement for original package. I think it is safe to switch to this one.
