### PR TITLE
Fix PHPUnit deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,15 +28,6 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-${{ matrix.php }}--${{ matrix.laravel }}--node-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.php }}--${{ matrix.laravel }}-node-
-
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
@@ -45,7 +36,6 @@ jobs:
         coverage: none
 
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
         composer remove --dev laravel/pint --no-interaction --no-update
         composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .php_cs.dist
 .php-cs-fixer.php
 .php-cs-fixer.cache
-.phpunit.result.cache
+.phpunit.cache
 composer.lock
 /assets/
 /phpunit.xml.bak

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     }
   },
   "scripts": {
-    "test": "vendor/bin/phpunit"
+    "test": " COLLISION_PRINTER=1 vendor/bin/phpunit --no-output"
   },
   "extra": {
     "laravel": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          backupGlobals="false"
-         backupStaticAttributes="false"
+         backupStaticProperties="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
+         cacheDirectory=".phpunit.cache"
 >
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="default">
-      <directory suffix="Test.php">tests</directory>
-    </testsuite>
-  </testsuites>
-  <php>
-    <env name="SPEC_PATH" value="./tests/Fixtures"/>
-    <env name="SPEC_URL_PARAMS" value=""/>
-  </php>
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="SPEC_PATH" value="./tests/Fixtures"/>
+        <env name="SPEC_URL_PARAMS" value=""/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -233,7 +233,7 @@ class RequestValidatorTest extends TestCase
         }
     }
 
-    public function nullableProvider(): array
+    public static function nullableProvider(): array
     {
         $validResponse = true;
 
@@ -315,7 +315,7 @@ class RequestValidatorTest extends TestCase
         }
     }
 
-    public function oneOfSchemaProvider(): array
+    public static function oneOfSchemaProvider(): array
     {
         $valid = true;
         $invalid = false;
@@ -375,7 +375,7 @@ class RequestValidatorTest extends TestCase
         }
     }
 
-    public function anyOfSchemaProvider(): array
+    public static function anyOfSchemaProvider(): array
     {
         $valid = true;
         $invalid = false;
@@ -433,7 +433,7 @@ class RequestValidatorTest extends TestCase
         }
     }
 
-    public function allOfSchemaProvider(): array
+    public static function allOfSchemaProvider(): array
     {
         $valid = true;
         $invalid = false;
@@ -677,7 +677,7 @@ class RequestValidatorTest extends TestCase
             ->assertValidResponse();
     }
 
-    public function nullableObjectProvider(): array
+    public static function nullableObjectProvider(): array
     {
         return [
             [['name' => 'dog', 'friend' => null], true],
@@ -736,7 +736,7 @@ class RequestValidatorTest extends TestCase
         }
     }
 
-    public function requiredReadOnlySchemaProvider(): array
+    public static function requiredReadOnlySchemaProvider(): array
     {
         $valid = true;
         $invalid = false;

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -253,7 +253,7 @@ class ResponseValidatorTest extends TestCase
         }
     }
 
-    public function nullableProvider(): array
+    public static function nullableProvider(): array
     {
         $validResponse = true;
         $invalidResponse = false;
@@ -352,7 +352,7 @@ class ResponseValidatorTest extends TestCase
         }
     }
 
-    public function oneOfSchemaProvider(): array
+    public static function oneOfSchemaProvider(): array
     {
         $valid = true;
         $invalid = false;
@@ -416,7 +416,7 @@ class ResponseValidatorTest extends TestCase
         }
     }
 
-    public function anyOfSchemaProvider(): array
+    public static function anyOfSchemaProvider(): array
     {
         $valid = true;
         $invalid = false;
@@ -480,7 +480,7 @@ class ResponseValidatorTest extends TestCase
         }
     }
 
-    public function allOfSchemaProvider(): array
+    public static function allOfSchemaProvider(): array
     {
         $valid = true;
         $invalid = false;
@@ -697,7 +697,7 @@ class ResponseValidatorTest extends TestCase
         }
     }
 
-    public function requiredWriteOnlySchemaProvider(): array
+    public static function requiredWriteOnlySchemaProvider(): array
     {
         $valid = true;
         $invalid = false;


### PR DESCRIPTION
Fix deprecations and update test script to get collision printer.

The vendor cache was dropped in order to always get fresh dependencies. On the first attempt, PHPUnit 9 was installed from the cache