### PR TITLE
Better exception handling

### DIFF
--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -44,13 +44,16 @@ class Assertions
         return fn () => $this->runAssertion(function () {
             $exception = app('spectator')->requestException;
 
-            $this->expectsTrue($exception, [
-                InvalidPathException::class,
+            $this->expectsFalse($exception, [
                 MalformedSpecException::class,
                 MissingSpecException::class,
-                RequestValidationException::class,
                 TypeErrorException::class,
                 UnresolvableReferenceException::class,
+            ]);
+
+            $this->expectsTrue($exception, [
+                InvalidPathException::class,
+                RequestValidationException::class,
             ]);
 
             return $this;
@@ -63,6 +66,9 @@ class Assertions
             $exception = app('spectator')->responseException;
 
             $this->expectsFalse($exception, [
+                InvalidPathException::class,
+                MalformedSpecException::class,
+                MissingSpecException::class,
                 ResponseValidationException::class,
                 TypeErrorException::class,
                 UnresolvableReferenceException::class,
@@ -86,10 +92,16 @@ class Assertions
         return fn ($status = null) => $this->runAssertion(function () use ($status) {
             $exception = app('spectator')->responseException;
 
-            $this->expectsTrue($exception, [
-                ResponseValidationException::class,
+            $this->expectsFalse($exception, [
+                MalformedSpecException::class,
+                MissingSpecException::class,
                 TypeErrorException::class,
                 UnresolvableReferenceException::class,
+            ]);
+
+            $this->expectsTrue($exception, [
+                InvalidPathException::class,
+                ResponseValidationException::class,
             ]);
 
             if ($status) {

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -7,6 +7,7 @@ use cebe\openapi\exceptions\UnresolvableReferenceException;
 use Closure;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\ExpectationFailedException;
 use Spectator\Concerns\HasExpectations;
 use Spectator\Exceptions\InvalidPathException;
 use Spectator\Exceptions\MalformedSpecException;
@@ -186,8 +187,8 @@ class Assertions
 
             try {
                 return $closure();
-            } catch (\Exception $exception) {
-                throw new \ErrorException($exception->getMessage(), $exception->getCode(), E_WARNING, $original['file'], $original['line']);
+            } catch (ExpectationFailedException $exception) {
+                throw new \ErrorException($exception->getMessage(), $exception->getCode(), E_WARNING, $original['file'], $original['line'], $exception);
             }
         };
     }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -17,6 +17,7 @@ use Spectator\Exceptions\InvalidPathException;
 use Spectator\Exceptions\MalformedSpecException;
 use Spectator\Exceptions\MissingSpecException;
 use Spectator\Exceptions\RequestValidationException;
+use Spectator\Exceptions\ResponseValidationException;
 use Spectator\Validation\RequestValidator;
 use Spectator\Validation\ResponseValidator;
 
@@ -56,6 +57,7 @@ class Middleware
             $pathItem = $this->pathItem($requestPath, $request->method());
         } catch (InvalidPathException|MalformedSpecException|MissingSpecException|TypeErrorException|UnresolvableReferenceException $exception) {
             $this->spectator->captureRequestValidation($exception);
+            $this->spectator->captureResponseValidation($exception);
 
             return $next($request);
         }
@@ -94,7 +96,7 @@ class Middleware
                 $pathItem,
                 $request->method()
             );
-        } catch (\Exception $exception) {
+        } catch (RequestValidationException $exception) {
             $this->spectator->captureRequestValidation($exception);
         }
 
@@ -107,7 +109,7 @@ class Middleware
                 $pathItem->{strtolower($request->method())},
                 $this->version
             );
-        } catch (\Exception $exception) {
+        } catch (ResponseValidationException $exception) {
             $this->spectator->captureResponseValidation($exception);
         }
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -19,6 +19,8 @@ class AssertionsTest extends TestCase
         $this->app->register(SpectatorServiceProvider::class);
 
         Spectator::using('Test.v1.json');
+
+        $this->withoutExceptionHandling();
     }
 
     public function test_asserts_invalid_path()
@@ -80,6 +82,8 @@ class AssertionsTest extends TestCase
 
     public function test_exception_points_to_mixin_method()
     {
+        $this->withExceptionHandling();
+
         $this->expectException(ErrorException::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('No response object matching returned status code [500].');
@@ -93,8 +97,10 @@ class AssertionsTest extends TestCase
             ->assertValidResponse(200);
     }
 
-    public function test_request_assertion_does_not_format_laravel_validation_response_errors_when_errors_are_not_suppressed(): void
-    {
+    public function test_request_assertion_does_not_format_laravel_validation_response_errors_when_errors_are_not_suppressed(
+    ): void {
+        $this->withoutExceptionHandling([ValidationException::class]);
+
         Config::set('spectator.suppress_errors', false);
 
         Route::post('/users', function () {
@@ -117,7 +123,7 @@ class AssertionsTest extends TestCase
 
     public function test_asserts_path_exists()
     {
-        Route::get('/users')->middleware(Middleware::class);
+        Route::get('/users', fn () => 'ok')->middleware(Middleware::class);
 
         $this->getJson('/users')
             ->assertPathExists();
@@ -129,7 +135,7 @@ class AssertionsTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('Path [GET /invalid] not found in spec.');
 
-        Route::get('/invalid')->middleware(Middleware::class);
+        Route::get('/invalid', fn () => 'ok')->middleware(Middleware::class);
 
         $this->getJson('/invalid')
             ->assertPathExists();

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -19,8 +19,6 @@ class AssertionsTest extends TestCase
         $this->app->register(SpectatorServiceProvider::class);
 
         Spectator::using('Test.v1.json');
-
-        $this->withoutExceptionHandling();
     }
 
     public function test_asserts_invalid_path()

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -16,6 +16,8 @@ class MiddlewareTest extends TestCase
         $this->app->register(SpectatorServiceProvider::class);
 
         Spectator::using('Test.v1.json');
+
+        $this->withoutExceptionHandling();
     }
 
     public function test_only_processes_request_once(): void

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -16,8 +16,6 @@ class MiddlewareTest extends TestCase
         $this->app->register(SpectatorServiceProvider::class);
 
         Spectator::using('Test.v1.json');
-
-        $this->withoutExceptionHandling();
     }
 
     public function test_only_processes_request_once(): void

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -22,6 +22,8 @@ class RequestValidatorTest extends TestCase
         parent::setUp();
 
         $this->app->register(SpectatorServiceProvider::class);
+
+        $this->withoutExceptionHandling();
     }
 
     public function test_cannot_resolve_prefixed_path(): void
@@ -201,7 +203,7 @@ class RequestValidatorTest extends TestCase
     ): void {
         Spectator::using("Nullable.$version.json");
 
-        Route::post('/users')->middleware(Middleware::class);
+        Route::post('/users', fn () => 'ok')->middleware(Middleware::class);
 
         $payload = [
             'name' => 'Adam Campbell',
@@ -526,7 +528,7 @@ class RequestValidatorTest extends TestCase
         Spectator::using('Test.v1.json');
 
         // When testing query parameters, they are not found nor checked by RequestValidator->validateParameters().
-        Route::get('/users-by-id/{user}', function (int $user) {
+        Route::get('/users-by-id/{user}', function (string $user) {
             return [];
         })->middleware(Middleware::class);
 
@@ -725,7 +727,7 @@ class RequestValidatorTest extends TestCase
     ): void {
         Spectator::using('RequiredReadOnly.v1.yml');
 
-        Route::post('/users')->middleware(Middleware::class);
+        Route::post('/users', fn () => 'ok')->middleware(Middleware::class);
 
         if ($is_valid) {
             $this->postJson('/users', $payload)

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -22,8 +22,6 @@ class RequestValidatorTest extends TestCase
         parent::setUp();
 
         $this->app->register(SpectatorServiceProvider::class);
-
-        $this->withoutExceptionHandling();
     }
 
     public function test_cannot_resolve_prefixed_path(): void

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -531,10 +531,11 @@ class ResponseValidatorTest extends TestCase
 
         Route::get('/')->middleware(Middleware::class);
 
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.');
+
         $this->getJson('/')
-            ->assertInvalidRequest()
-            ->assertInvalidResponse()
-            ->assertValidationMessage('The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.');
+            ->assertInvalidResponse();
     }
 
     // https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
@@ -660,9 +661,9 @@ class ResponseValidatorTest extends TestCase
 
     public function test_array_any_of(): void
     {
-        Spectator::using('ArrayAnyOf.v1.yaml');
+        Spectator::using('ArrayAnyOf.v1.yml');
 
-        Route::patch('/pets', static function () {
+        Route::get('/pets', static function () {
             return [
                 // PetByAge
                 ['age' => 5, 'nickname' => 'nick'],

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Spectator\Middleware;
 use Spectator\Spectator;
 use Spectator\SpectatorServiceProvider;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResponseValidatorTest extends TestCase
 {
@@ -19,6 +20,8 @@ class ResponseValidatorTest extends TestCase
         $this->app->register(SpectatorServiceProvider::class);
 
         Spectator::using('Test.v1.json');
+
+        $this->withoutExceptionHandling();
     }
 
     public function test_validates_valid_json_response(): void
@@ -133,6 +136,8 @@ class ResponseValidatorTest extends TestCase
 
         $response = $this->getJson("/orders/{$uuid}")
             ->assertValidResponse(200);
+
+        $this->withoutExceptionHandling([NotFoundHttpException::class]);
 
         $response = $this->getJson('/orders/invalid')
             ->assertValidResponse(404);
@@ -529,7 +534,7 @@ class ResponseValidatorTest extends TestCase
     {
         Spectator::using('Malformed.v1.yaml');
 
-        Route::get('/')->middleware(Middleware::class);
+        Route::get('/', fn () => 'ok')->middleware(Middleware::class);
 
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage('The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.');

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -20,8 +20,6 @@ class ResponseValidatorTest extends TestCase
         $this->app->register(SpectatorServiceProvider::class);
 
         Spectator::using('Test.v1.json');
-
-        $this->withoutExceptionHandling();
     }
 
     public function test_validates_valid_json_response(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,4 +26,11 @@ abstract class TestCase extends Orchestra
     {
         return ['Spectator\SpectatorServiceProvider'];
     }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutExceptionHandling();
+    }
 }


### PR DESCRIPTION
This PR improves exception handling int spectator code base, especially in the tests.

All decisions I made can be discussed and revert as needed

What is done and why :

- Tests are now run `withoutExceptionHandling` which allows us to be informed of internal issues during the request, especially during request and response validation in the middleware. Without that, any error occurring there will be catched by the exception handler and transformed to a 500 response. The error can be hidden if the assertion made is an `assertInvalidResponse` for example. The tests requiring Laravel to handle some exceptions (ValidationException for example) explicitly exclude the exception during setup.
- InvalidPathException, MalformedSpecException, MissingSpecException, TypeErrorException, UnresolvableReferenceException are now set in `captureResponseValidation($exception)`. This way, a test like 
```
$this->get('/route-missing-in-openapi')->assertValidRequest();
```
will now fail. Previously, it passed because no exception was set in `responseException`.
- `assertInvalidRequest` and `assertInvalidResponse` now require the specification to exist, to be well formatted and the route to exist. IMO, if the developer wants to check that a request is invalid accordingly to the openapi contract, they will want to know that some of the setup they did is not correct : invalid openapi, missing route, ...
- content-type resolution was buggy and now fixed (the exception was hidden by the fact that the tests were run with laravel exception handling) 
- failing tests were fixed