### PR TITLE
Support substituted backed enum in path

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -95,6 +95,8 @@ class RequestValidator extends AbstractValidator
                     $parameter_value = $route->parameters()[$parameter->name];
                     if ($parameter_value instanceof Model) {
                         $parameter_value = $route->originalParameters()[$parameter->name];
+                    } elseif ($parameter_value instanceof \BackedEnum) {
+                        $parameter_value = $route->originalParameters()[$parameter->name];
                     }
                 } elseif ($parameter->in === 'query' && $this->hasQueryParam($parameter->name)) {
                     $parameter_value = $this->getQueryParam($parameter->name);
@@ -109,7 +111,7 @@ class RequestValidator extends AbstractValidator
                 }
 
                 if ($parameter_value) {
-                    if ($expected_parameter_schema->type && gettype($parameter_value) !== $expected_parameter_schema->type) {
+                    if (isset($expected_parameter_schema->type) && gettype($parameter_value) !== $expected_parameter_schema->type) {
                         $expected_type = $expected_parameter_schema->type;
 
                         if ($expected_type === 'number') {

--- a/tests/Fixtures/Enum.yml
+++ b/tests/Fixtures/Enum.yml
@@ -1,0 +1,46 @@
+openapi: 3.1.0
+info:
+  title: Enum
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /enum-in-path/{type}:
+    parameters:
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+          enum:
+            - name
+            - email
+    get:
+      summary: Request with enum in path
+      tags: []
+      responses:
+        '204':
+          description: No Content
+  /enum-in-path-via-reference/{type}:
+    parameters:
+      - in: path
+        name: type
+        required: true
+        schema:
+          $refs: '#/components/schemas/TestEnum'
+    get:
+      summary: Request with enum in path via reference
+      tags: []
+      responses:
+        '204':
+          description: No Content
+
+components:
+  schemas:
+    TestEnum:
+      type: string
+      enum:
+        - name
+        - email
+
+


### PR DESCRIPTION
This PR fixes the validation when backed enum is substituted in the controller.

The value is used for validation.
