### PR TITLE
Fix filterProperties when data does not contain properties

### DIFF
--- a/src/Validation/AbstractValidator.php
+++ b/src/Validation/AbstractValidator.php
@@ -60,6 +60,10 @@ abstract class AbstractValidator
                 return $data;
         }
 
+        if (! isset($data->properties)) {
+            return $data;
+        }
+
         /**
          * Create a new array of properties that need to be filtered out.
          */

--- a/tests/Fixtures/Arrays.v1.yaml
+++ b/tests/Fixtures/Arrays.v1.yaml
@@ -71,5 +71,21 @@ paths:
           name: orgUuid
           in: path
           required: true
+  /array-of-strings:
+    get:
+      summary: Get arrays of string
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: string
 components:
   schemas: {}

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -683,6 +683,44 @@ class ResponseValidatorTest extends TestCase
             ]);
     }
 
+    /**
+     * @dataProvider arrayOfStringsProvider
+     */
+    public function test_array_of_strings(mixed $payload, bool $isValid): void
+    {
+        Spectator::using('Arrays.v1.yaml');
+
+        Route::get('/array-of-strings', static function () use ($payload) {
+            return ['data' => $payload];
+        })->middleware(Middleware::class);
+
+        if ($isValid) {
+            $this->getJson('/array-of-strings')
+                ->assertValidResponse();
+        } else {
+            $this->getJson('/array-of-strings')
+                ->assertInvalidResponse();
+        }
+    }
+
+    public static function arrayOfStringsProvider(): array
+    {
+        return [
+            'valid' => [
+                ['foo', 'bar'],
+                true,
+            ],
+            'invalid as string' => [
+                'foo',
+                false,
+            ],
+            'invalid as object' => [
+                ['foo' => 'bar'],
+                false,
+            ],
+        ];
+    }
+
     public function test_array_any_of(): void
     {
         Spectator::using('ArrayAnyOf.v1.yml');


### PR DESCRIPTION
In some cases, we try to filter properties of something which does not have any.

This PR fixes it, allowing to define and validate json responses like 
```json
{
  "data": ["foo", "bar", "baz"]
}
```
    
