### PR TITLE
Add support for dictionaries

### DIFF
--- a/src/Validation/AbstractValidator.php
+++ b/src/Validation/AbstractValidator.php
@@ -60,6 +60,10 @@ abstract class AbstractValidator
                 return $data;
         }
 
+        if (isset($data->type) && $data->type === 'object') {
+            $data->properties ??= new \stdClass();
+        }
+
         /**
          * Create a new array of properties that need to be filtered out.
          */

--- a/src/Validation/AbstractValidator.php
+++ b/src/Validation/AbstractValidator.php
@@ -66,7 +66,6 @@ abstract class AbstractValidator
 
         if (! isset($data->properties)) {
             return $data;
-
         }
 
         /**

--- a/tests/Fixtures/Dictionary.v1.yml
+++ b/tests/Fixtures/Dictionary.v1.yml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Dictionary.v1
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /dictionary-of-integers:
+    get:
+      summary: Get dictionary of integers
+      tags: [ ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties:
+                      type: integer
+components:
+  schemas: {}

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -773,4 +773,46 @@ class ResponseValidatorTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider objectAsDictionaryProvider
+     */
+    public function test_object_as_dictionary(mixed $payload, bool $isValid): void
+    {
+        Spectator::using('Dictionary.v1.yml');
+
+        Route::get('/dictionary-of-integers', static function () use ($payload) {
+            return ['data' => $payload];
+        })->middleware(Middleware::class);
+
+        if ($isValid) {
+            $this->getJson('/dictionary-of-integers')
+                ->assertValidResponse();
+        } else {
+            $this->getJson('/dictionary-of-integers')
+                ->assertInvalidResponse();
+        }
+    }
+
+    public static function objectAsDictionaryProvider(): array
+    {
+        return [
+            'valid' => [
+                ['foo' => 1, 'bar' => -1],
+                true,
+            ],
+            'invalid as string' => [
+                'foo',
+                false,
+            ],
+            'invalid as array' => [
+                [1, 2],
+                false,
+            ],
+            'invalid as dictionary of string' => [
+                ['foo' => 'foo', 'bar' => 'bar'],
+                false,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Dictionaries are objects in which the keys are not known but we can still validate the format of the values.

For example : 
```json
{
    "data": {
        "2024-01-27": 6,
        "2024-01-28": 7
    }
}
```

Before this fix, we had the error 
```
ErrorException: Undefined property: stdClass::$properties
/spectator/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:255
/spectator/src/Validation/AbstractValidator.php:72
/spectator/src/Validation/AbstractValidator.php:114
....
```

Fixes #143 
Fixes #167