### PR TITLE
Expected empty response body

### DIFF
--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -44,6 +44,8 @@ class ResponseValidator extends AbstractValidator
 
         if ($responseObject->content) {
             $this->parseResponse($responseObject);
+        } elseif ($this->responseContent() !== '') {
+            throw new ResponseValidationException('Response body is expected to be empty.');
         }
     }
 
@@ -164,7 +166,7 @@ class ResponseValidator extends AbstractValidator
      */
     protected function body($contentType, $schemaType)
     {
-        $body = $this->response instanceof StreamedResponse ? $this->streamedContent() : $this->response->getContent();
+        $body = $this->responseContent();
 
         if (in_array($schemaType, ['object', 'array', 'allOf', 'anyOf', 'oneOf'], true)) {
             if (in_array($contentType, ['application/json', 'application/vnd.api+json', 'application/problem+json'])) {
@@ -175,6 +177,11 @@ class ResponseValidator extends AbstractValidator
         }
 
         return $body;
+    }
+
+    protected function responseContent(): string
+    {
+        return $this->response instanceof StreamedResponse ? $this->streamedContent() : $this->response->getContent();
     }
 
     protected function streamedContent(): string

--- a/tests/Fixtures/EmptyResponse.yml
+++ b/tests/Fixtures/EmptyResponse.yml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: EmptyResponse
+  version: '1.0'
+servers:
+  - url: 'https://api.protect.earth/'
+    description: Production
+paths:
+  /empty:
+    get:
+      summary: Get empty response
+      tags: []
+      responses:
+        '200':
+          description: Ok
+components:
+  schemas: {}

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -88,6 +88,33 @@ class ResponseValidatorTest extends TestCase
             ->assertValidResponse();
     }
 
+    public function test_validates_valid_empty_response(): void
+    {
+        Spectator::using('EmptyResponse.yml');
+
+        Route::get('/empty', static function () {
+            return response('');
+        })->middleware(Middleware::class);
+
+        $this->getJson('/empty')
+            ->assertValidRequest()
+            ->assertValidResponse(200);
+    }
+
+    public function test_validates_invalid_empty_response(): void
+    {
+        Spectator::using('EmptyResponse.yml');
+
+        Route::get('/empty', static function () {
+            return response('Hello world!');
+        })->middleware(Middleware::class);
+
+        $this->getJson('/empty')
+            ->assertValidRequest()
+            ->assertInvalidResponse(200)
+            ->assertValidationMessage('Response body is expected to be empty.');
+    }
+
     public function test_validates_valid_problem_json_response()
     {
         Route::get('/users', function () {


### PR DESCRIPTION
From now, a non empty response body will be considered invalid against a specification not defining a response content

Fixes #165 