### PR TITLE
Expects true fails if the throwable is null

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: src/Assertions.php
 
 		-
-			message: "#^Method Spectator\\\\Assertions\\:\\:expectsTrue\\(\\) invoked with 2 parameters, 0 required\\.$#"
+			message: "#^Method Spectator\\\\Assertions\\:\\:expectsTrue\\(\\) invoked with 3 parameters, 0 required\\.$#"
 			count: 2
 			path: src/Assertions.php
 

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -55,7 +55,7 @@ class Assertions
             $this->expectsTrue($exception, [
                 InvalidPathException::class,
                 RequestValidationException::class,
-            ]);
+            ], 'Failed asserting that the request is invalid.');
 
             return $this;
         });
@@ -103,7 +103,7 @@ class Assertions
             $this->expectsTrue($exception, [
                 InvalidPathException::class,
                 ResponseValidationException::class,
-            ]);
+            ], 'Failed asserting that the response is invalid.');
 
             if ($status) {
                 $actual = $this->getStatusCode();

--- a/src/Concerns/HasExpectations.php
+++ b/src/Concerns/HasExpectations.php
@@ -35,7 +35,7 @@ trait HasExpectations
          * @param array $exceptions
          * @return void
          */
-        return function (?Throwable $throwable = null, array $exceptions = []) {
+        return function (?Throwable $throwable = null, array $exceptions = [], string $message = '') {
             if ($throwable) {
                 $class = get_class($throwable);
 
@@ -44,7 +44,7 @@ trait HasExpectations
                     $throwable->getMessage(),
                 );
             } else {
-                PHPUnit::assertTrue(true);
+                PHPUnit::assertTrue(false, $message);
             }
         };
     }

--- a/tests/Fixtures/AllOf.v1.yml
+++ b/tests/Fixtures/AllOf.v1.yml
@@ -48,6 +48,9 @@ paths:
                             owner:
                               type: string
                               nullable: true
+                          required:
+                            - id
+                            - owner
                         - $ref: '#/components/schemas/Dog'
 
 components:

--- a/tests/Fixtures/Enum.yml
+++ b/tests/Fixtures/Enum.yml
@@ -27,7 +27,7 @@ paths:
         name: type
         required: true
         schema:
-          $refs: '#/components/schemas/TestEnum'
+          $ref: '#/components/schemas/TestEnum'
     get:
       summary: Request with enum in path via reference
       tags: []

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -4,7 +4,6 @@ namespace Spectator\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
@@ -793,8 +792,6 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Enum.yml');
 
-        $this->withoutExceptionHandling([BackedEnumCaseNotFoundException::class]);
-
         Route::get('/enum-in-path/{type}', function (TestEnum $type) {
             return response()->noContent();
         })->middleware([SubstituteBindings::class, Middleware::class]);
@@ -814,8 +811,6 @@ class RequestValidatorTest extends TestCase
     public function test_enum_in_path_via_reference(string $type, bool $isValid): void
     {
         Spectator::using('Enum.yml');
-
-        $this->withoutExceptionHandling([BackedEnumCaseNotFoundException::class]);
 
         Route::get('/enum-in-path-via-reference/{type}', function (TestEnum $type) {
             return response()->noContent();
@@ -838,7 +833,7 @@ class RequestValidatorTest extends TestCase
                 true,
             ],
             'invalid enum' => [
-                'foo',
+                'invalid',
                 false,
             ],
         ];
@@ -853,4 +848,5 @@ enum TestEnum: string
 {
     case name = 'name';
     case email = 'email';
+    case invalid = 'invalid';
 }

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -442,10 +442,6 @@ class ResponseValidatorTest extends TestCase
             return ['data' => $payload];
         })->middleware(Middleware::class);
 
-        $this->getJson('/nullable-array-of-nullable-string')
-            ->assertValidRequest()
-            ->assertValidResponse();
-
         if ($isValid) {
             $this->getJson('/nullable-array-of-nullable-string')
                 ->assertValidRequest()
@@ -483,7 +479,7 @@ class ResponseValidatorTest extends TestCase
             ],
             '3.0, array with int' => [
                 $v30,
-                ['foo', null],
+                [1, null],
                 $invalidResponse,
             ],
             '3.1, null' => [
@@ -503,10 +499,9 @@ class ResponseValidatorTest extends TestCase
             ],
             '3.1, array with int' => [
                 $v31,
-                ['foo', null],
+                [1, null],
                 $invalidResponse,
             ],
-
         ];
     }
 
@@ -770,7 +765,7 @@ class ResponseValidatorTest extends TestCase
                 ],
                 $invalid,
             ],
-            'invalid, invalid owner missing' => [
+            'invalid, invalid owner' => [
                 [
                     'id' => 1,
                     'pet_type' => 'Dog',

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Spectator\Tests;
 
+use ErrorException;
 use Exception;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
@@ -67,6 +68,26 @@ class ResponseValidatorTest extends TestCase
             ->assertValidRequest()
             ->assertInvalidResponse()
             ->assertValidationMessage('All array items must match schema');
+    }
+
+    public function test_fails_to_invalidate_valid_json_response(): void
+    {
+        Route::get('/users', static function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })->middleware(Middleware::class);
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage("Failed asserting that the response is invalid.\nFailed asserting that false is true.");
+
+        $this->getJson('/users')
+            ->assertValidRequest()
+            ->assertInvalidResponse();
     }
 
     public function test_validates_valid_streamed_json_response(): void


### PR DESCRIPTION
Currently, passing `null` to `expectsTrue` passes but I think it is an error.

Indeed, if no exception was raised, `expectsTrue` will pass and a valid implementation can execute this test without failing 
```php
$this->getJson('/api/path')
    ->assertValidRequest()
    ->assertInvalidRequest()
    ->assertValidResponse()
    ->assertInvalidResponse();
```
I think that a request cannot be both valid and invalid.

This behavior caused false-positive in the tests. I fixed them