### PR TITLE
Give Http Code assertion more priority in response assertion

### DIFF
--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -64,6 +64,10 @@ class Assertions
     public function assertValidResponse()
     {
         return fn ($status = null) => $this->runAssertion(function () use ($status) {
+            if ($status) {
+                $this->assertStatus($status);
+            }
+
             $exception = app('spectator')->responseException;
 
             $this->expectsFalse($exception, [
@@ -75,15 +79,6 @@ class Assertions
                 UnresolvableReferenceException::class,
             ]);
 
-            if ($status) {
-                $actual = $this->getStatusCode();
-
-                PHPUnit::assertTrue(
-                    $actual === $status,
-                    "Expected status code {$status} but received {$actual}."
-                );
-            }
-
             return $this;
         });
     }
@@ -91,6 +86,10 @@ class Assertions
     public function assertInvalidResponse()
     {
         return fn ($status = null) => $this->runAssertion(function () use ($status) {
+            if ($status) {
+                $this->assertStatus($status);
+            }
+
             $exception = app('spectator')->responseException;
 
             $this->expectsFalse($exception, [
@@ -104,15 +103,6 @@ class Assertions
                 InvalidPathException::class,
                 ResponseValidationException::class,
             ], 'Failed asserting that the response is invalid.');
-
-            if ($status) {
-                $actual = $this->getStatusCode();
-
-                PHPUnit::assertTrue(
-                    $actual === $status,
-                    "Expected status code {$status} but received {$actual}."
-                );
-            }
 
             return $this;
         });

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -82,7 +82,7 @@ class AssertionsTest extends TestCase
 
         $this->expectException(ErrorException::class);
         $this->expectExceptionCode(0);
-        $this->expectExceptionMessage('No response object matching returned status code [500].');
+        $this->expectExceptionMessage('Expected response status code [200] but received 500.');
 
         Route::get('/users', function () {
             throw new \Exception('Explosion');

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -136,6 +136,26 @@ class ResponseValidatorTest extends TestCase
             ->assertValidationMessage('Response body is expected to be empty.');
     }
 
+    public function test_validates_status_code(): void
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Expected response status code [200] but received 201.');
+
+        Route::get('/users', static function () {
+            return response([
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ], 201);
+        })->middleware(Middleware::class);
+
+        $this->getJson('/users')
+            ->assertValidRequest()
+            ->assertValidResponse(200);
+    }
+
     public function test_validates_valid_problem_json_response()
     {
         Route::get('/users', function () {


### PR DESCRIPTION
Http code assertion has more priority than schema validation when given to `assertValidResponse` and `assertInvalidResponse`.

I also simplify the implementation using Laravel built-in assertion.

Fixes #121 