### PR TITLE
Query param can be an array

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -219,7 +219,10 @@ class RequestValidator extends AbstractValidator
         return Arr::has($this->request->query->all(), $this->convertQueryParameterToDotted($parameterName));
     }
 
-    private function getQueryParam(string $parameterName): ?string
+    /**
+     * @return string|array<array-key, mixed>|null
+     */
+    private function getQueryParam(string $parameterName): string|array|null
     {
         return Arr::get($this->request->query->all(), $this->convertQueryParameterToDotted($parameterName));
     }

--- a/tests/Fixtures/Arrays.v1.yml
+++ b/tests/Fixtures/Arrays.v1.yml
@@ -87,5 +87,19 @@ paths:
                     type: array
                     items:
                       type: string
+  /parameter-as-array:
+    parameters:
+      - name: arrayParam
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+    get:
+      summary: Get arrays of string
+      tags: [ ]
+      responses:
+        '204':
+          description: No Content
 components:
   schemas: {}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -519,6 +519,23 @@ class RequestValidatorTest extends TestCase
             ->assertValid();
     }
 
+    public function test_handles_array_query_parameters(): void
+    {
+        Spectator::using('Arrays.v1.yml');
+
+        // When testing query parameters, they are not found nor checked by RequestValidator->validateParameters().
+        Route::get('/parameter-as-array', function () {
+            return response()->noContent();
+        })->middleware(Middleware::class);
+
+        $this->get('/parameter-as-array?arrayParam=foo')
+            ->assertValidationMessage("The data (string) must match the type: array")
+            ->assertInvalidRequest();
+
+        $this->get('/parameter-as-array?arrayParam[]=foo&arrayParam[]=bar')
+            ->assertValidRequest();
+    }
+
     public function test_handles_query_parameters_int(): void
     {
         Spectator::using('Test.v1.json');

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -529,7 +529,7 @@ class RequestValidatorTest extends TestCase
         })->middleware(Middleware::class);
 
         $this->get('/parameter-as-array?arrayParam=foo')
-            ->assertValidationMessage("The data (string) must match the type: array")
+            ->assertValidationMessage('The data (string) must match the type: array')
             ->assertInvalidRequest();
 
         $this->get('/parameter-as-array?arrayParam[]=foo&arrayParam[]=bar')


### PR DESCRIPTION
Fixes a bug introduced in #184 