### PR TITLE
Remove binding between path parameter in openapi and Laravel route declaration

### DIFF
--- a/tests/Fixtures/Test.v1.json
+++ b/tests/Fixtures/Test.v1.json
@@ -239,6 +239,36 @@
         "operationId": "get-users-user"
       }
     },
+    "/users/me": {
+      "get": {
+        "summary": "Get current user",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-users-user"
+      }
+    },
     "/users-by-id/{user}": {
       "parameters": [
         {

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -145,7 +145,7 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::bind('postUuid', fn() => new TestUser);
+        Route::bind('postUuid', fn () => new TestUser);
 
         Route::get('/posts/{postUuid}', function () {
             return [
@@ -154,7 +154,7 @@ class RequestValidatorTest extends TestCase
             ];
         })->middleware([SubstituteBindings::class, Middleware::class]);
 
-        $this->getJson('/posts/' . Str::uuid()->toString())
+        $this->getJson('/posts/'.Str::uuid()->toString())
             ->assertValidRequest();
     }
 
@@ -162,7 +162,7 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::bind('postUuid', fn() => new TestUser);
+        Route::bind('postUuid', fn () => new TestUser);
 
         Route::get('/posts/{postUuid}', function () {
             return [
@@ -179,7 +179,7 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::bind('postUuid', fn() => new TestUser);
+        Route::bind('postUuid', fn () => new TestUser);
 
         Route::get('/posts/{postUuid}/comments/{comment}', function () {
             return [
@@ -188,7 +188,7 @@ class RequestValidatorTest extends TestCase
             ];
         })->middleware([SubstituteBindings::class, Middleware::class]);
 
-        $this->getJson('/posts/' . Str::uuid()->toString() . '/comments/1')
+        $this->getJson('/posts/'.Str::uuid()->toString().'/comments/1')
             ->assertValidRequest();
     }
 
@@ -869,6 +869,22 @@ class RequestValidatorTest extends TestCase
         })->middleware(Middleware::class);
 
         $this->post('/upload', ['file' => UploadedFile::fake()->createWithContent('test.xlsx', 'Content')], ['Content-Type' => 'multipart/form-data'])
+            ->assertValidRequest();
+    }
+
+    public function test_parameter_decoupling(): void
+    {
+        Spectator::using('Test.v1.json');
+
+        Route::get('/users/{id}', function (TestUser $id) {
+            return [
+                'id' => 1,
+                'name' => 'Jim',
+                'email' => 'test@test.test',
+            ];
+        })->middleware([SubstituteBindings::class, Middleware::class]);
+
+        $this->getJson('/users/1')
             ->assertValidRequest();
     }
 }

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -129,13 +129,13 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::get('/users/{user}', function () {
+        Route::get('/users/{user}', function (TestUser $user) {
             return [
                 'id' => 1,
                 'name' => 'Jim',
                 'email' => 'test@test.test',
             ];
-        })->middleware(Middleware::class);
+        })->middleware([SubstituteBindings::class, Middleware::class]);
 
         $this->getJson('/users/1')
             ->assertValidRequest();
@@ -145,16 +145,16 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::bind('postUuid', TestUser::class);
+        Route::bind('postUuid', fn() => new TestUser);
 
         Route::get('/posts/{postUuid}', function () {
             return [
                 'id' => 1,
                 'title' => 'My Post',
             ];
-        })->middleware(Middleware::class);
+        })->middleware([SubstituteBindings::class, Middleware::class]);
 
-        $this->getJson('/posts/'.Str::uuid()->toString())
+        $this->getJson('/posts/' . Str::uuid()->toString())
             ->assertValidRequest();
     }
 
@@ -162,14 +162,14 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::bind('postUuid', TestUser::class);
+        Route::bind('postUuid', fn() => new TestUser);
 
         Route::get('/posts/{postUuid}', function () {
             return [
                 'id' => 1,
                 'title' => 'My Post',
             ];
-        })->middleware(Middleware::class);
+        })->middleware([SubstituteBindings::class, Middleware::class]);
 
         $this->getJson('/posts/invalid')
             ->assertInvalidRequest();
@@ -179,16 +179,16 @@ class RequestValidatorTest extends TestCase
     {
         Spectator::using('Test.v1.json');
 
-        Route::bind('postUuid', TestUser::class);
+        Route::bind('postUuid', fn() => new TestUser);
 
         Route::get('/posts/{postUuid}/comments/{comment}', function () {
             return [
                 'id' => 1,
                 'message' => 'My Comment',
             ];
-        })->middleware(Middleware::class);
+        })->middleware([SubstituteBindings::class, Middleware::class]);
 
-        $this->getJson('/posts/'.Str::uuid()->toString().'/comments/1')
+        $this->getJson('/posts/' . Str::uuid()->toString() . '/comments/1')
             ->assertValidRequest();
     }
 
@@ -875,6 +875,10 @@ class RequestValidatorTest extends TestCase
 
 class TestUser extends Model
 {
+    public function resolveRouteBinding($value, $field = null)
+    {
+        return new TestUser();
+    }
 }
 
 enum TestEnum: string


### PR DESCRIPTION
Before, having an openapi route like 

```json
    "/users/{id}": {
      "parameters": [
        {
          "schema": {
            "type": "string"
          },
          "name": "id",
          "in": "path",
          "required": true
        }
      ],
      ...
```
and a route declaration like 
```php
Route::get('users/{user}', ...);
```
was not possible because parameter names between the specification was used to get the parameter value in the Laravel world.

This PR adds a 'translation' step where we translate `id` into `user` (in this example).

I also changed the way that bindings are tested, in order to properly cover the test cases. `SubstituteBindings` middleware was missing.

Fixes #140 