### PR TITLE
Improve validation and casting of request parameters

### DIFF
--- a/tests/Fixtures/Arrays.v1.yml
+++ b/tests/Fixtures/Arrays.v1.yml
@@ -101,5 +101,27 @@ paths:
       responses:
         '204':
           description: No Content
+  /parameter-as-array-of-objects:
+    parameters:
+      - name: arrayParam
+        in: query
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+            required:
+              - id
+              - name
+    get:
+      summary: Get arrays of objects
+      tags: [ ]
+      responses:
+        '204':
+          description: No Content
 components:
   schemas: {}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -536,6 +536,22 @@ class RequestValidatorTest extends TestCase
             ->assertValidRequest();
     }
 
+    public function test_handles_array_of_object_query_parameters(): void
+    {
+        Spectator::using('Arrays.v1.yml');
+
+        Route::get('/parameter-as-array-of-objects', function () {
+            return response()->noContent();
+        })->middleware(Middleware::class);
+
+        $this->get('/parameter-as-array-of-objects?arrayParam[0][id]=1&arrayParam[0][name]=foo&arrayParam[1][id]=2')
+            ->assertValidationMessage('The required properties (name) are missing')
+            ->assertInvalidRequest();
+
+        $this->get('/parameter-as-array-of-objects?arrayParam[0][id]=1&arrayParam[0][name]=foo&arrayParam[1][id]=2&arrayParam[1][name]=bar')
+            ->assertValidRequest();
+    }
+
     public function test_handles_query_parameters_int(): void
     {
         Spectator::using('Test.v1.json');


### PR DESCRIPTION
Fixes #187 

Array query parameters containing objects are not correctly validated because the validator requires the objects to be actual objects and not associative arrays.

The parameter value is now correctly casted.

I also needed to improve parameter casting in order to recursively cast the parameter (in case of objects and arrays). It is not perfect but it's better than before. We could improve it if needed in the future.