### PR TITLE
Support charset and placeholder media types

### DIFF
--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -124,7 +124,9 @@ class ResponseValidator extends AbstractValidator
 
     protected function contentType(): ?string
     {
-        return $this->response->headers->get('Content-Type');
+        return $this->response->headers->get('Content-Type') !== null
+            ? Str::before($this->response->headers->get('Content-Type'), ';')
+            : null;
     }
 
     protected function schemaType(Schema $schema): ?string

--- a/tests/Fixtures/ContentType.yml
+++ b/tests/Fixtures/ContentType.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: ContentType
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /partial-match:
+    get:
+      summary: Get object
+      tags: [ ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/*:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  email:
+                    type: string
+  /joker:
+    get:
+      summary: Get string
+      tags: [ ]
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -241,6 +241,28 @@ class ResponseValidatorTest extends TestCase
             ->assertValidationMessage('All array items must match schema');
     }
 
+    public function test_with_partial_content_type_matching()
+    {
+        Spectator::using('ContentType.yml');
+        Route::get('/partial-match', function () {
+            return [
+                'id' => 1,
+                'name' => 'Jim',
+                'email' => 'test@test.test',
+            ];
+        })->middleware(Middleware::class);
+
+        $this->getJson('/partial-match')
+            ->assertValidResponse(200);
+
+        Route::get('/joker', function () {
+            return response('Hello world!', 200, ['Content-Type' => 'text/html']);
+        })->middleware(Middleware::class);
+
+        $this->getJson('/joker')
+            ->assertValidResponse(200);
+    }
+
     public function test_validates_problem_json_response_using_components()
     {
         $this->withoutExceptionHandling([NotFoundHttpException::class]);

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -173,6 +173,23 @@ class ResponseValidatorTest extends TestCase
             ->assertValidResponse(422);
     }
 
+    public function test_validates_valid_response_with_charset()
+    {
+        Route::get('/users', function () {
+            return response()->json([
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ], 422, ['Content-Type' => 'application/json; charset=utf-8']);
+        })->middleware(Middleware::class);
+
+        $this->getJson('/users')
+            ->assertValidRequest()
+            ->assertValidResponse(422);
+    }
+
     public function test_validates_invalid_content_type(): void
     {
         Route::get('/users', static function () {


### PR DESCRIPTION
The specification allows to define responses with placeholders : 

```yml
paths:
  /info/logo:
    get:
      responses:
        '200':           # Response
          description: OK
          content:       # Response body
            image/*:     # Media type
             schema: 
               type: string
               format: binary
```
https://swagger.io/docs/specification/media-types/

which is currently not possible.

This PR adds the support of that.

It also fixes a bug where a response having a content type like `application/json; charset=UTF-8` would not match the openapi 
```
ErrorException: Response did not match any specified content type.

  Expected: application/json
  Actual: application/json; charset=utf-8
```