### PR TITLE
Convert empty request body to object if an object is expected by OpenAPI definition

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -156,6 +156,10 @@ class RequestValidator extends AbstractValidator
             && in_array($contentType, ['application/json', 'application/vnd.api+json'])
         ) {
             $actualBodySchema = json_decode($this->request->getContent());
+
+            if ($actualBodySchema === [] && $expectedBodyRawSchema->type === 'object') {
+                $actualBodySchema = (object) [];
+            }
         } else {
             $actualBodySchema = $this->parseBodySchema();
         }

--- a/tests/Fixtures/EmptyRequestBodyAsArray.yml
+++ b/tests/Fixtures/EmptyRequestBodyAsArray.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Nullable-Object.v1
+  title: EmptyRequestBodyAsArray
   version: '1.0'
 servers:
   - url: 'http://localhost:3000'

--- a/tests/Fixtures/EmptyRequestBodyAsArray.yml
+++ b/tests/Fixtures/EmptyRequestBodyAsArray.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Nullable-Object.v1
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /pets:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/tests/Fixtures/EmptyRequestBodyAsObject.yml
+++ b/tests/Fixtures/EmptyRequestBodyAsObject.yml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: Nullable-Object.v1
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /pets:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/tests/Fixtures/EmptyRequestBodyAsObject.yml
+++ b/tests/Fixtures/EmptyRequestBodyAsObject.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Nullable-Object.v1
+  title: EmptyRequestBodyAsObject
   version: '1.0'
 servers:
   - url: 'http://localhost:3000'

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -192,6 +192,36 @@ class RequestValidatorTest extends TestCase
             ->assertValidRequest();
     }
 
+    public function test_empty_request_body_as_object(): void
+    {
+        Spectator::using('EmptyRequestBodyAsObject.yml');
+
+        Route::patch('/pets', function () {
+            return [
+                'id' => 1,
+                'name' => 'My Pet',
+            ];
+        })->middleware([Middleware::class]);
+
+        $this->patchJson('/pets')
+            ->assertValidRequest();
+    }
+
+    public function test_empty_request_body_as_array(): void
+    {
+        Spectator::using('EmptyRequestBodyAsArray.yml');
+
+        Route::patch('/pets', function () {
+            return [
+                'id' => 1,
+                'name' => 'My Pet',
+            ];
+        })->middleware([Middleware::class]);
+
+        $this->patchJson('/pets')
+            ->assertValidRequest();
+    }
+
     /**
      * @dataProvider nullableProvider
      */


### PR DESCRIPTION
If I execute an API call without a request body
```php
$this->patchJson('/pets')->assertValidRequest();
```
and my OpenAPI file says the request can contain an object (none of the properties are required),
```yaml
paths:
  /pets:
    patch:
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties: # none of the properties are required
                name:
                  type: string
```

then I currently get the following error: 
```
The data (array) must match the type: object

object++ <== The data (array) must match the type: object
    name: string
```
This PR fixes that. If the OpenAPI file says that an object is expected, then the empty array is converted to an empty object.