### PR TITLE
Fix: boolean casting

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -106,7 +106,7 @@ class RequestValidator extends AbstractValidator
                     $parameterValue = $this->request->cookies->get($parameter->name);
                 }
 
-                if ($parameterValue) {
+                if ($parameterValue !== null) {
                     $parameterValue = $this->castParameterValue($parameterValue, $expectedParameterSchema);
 
                     $result = $validator->validate($this->toObject($parameterValue), $expectedParameterSchema);
@@ -217,6 +217,9 @@ class RequestValidator extends AbstractValidator
                 $parameterValue,
                 fn (mixed $value) => $this->castParameterValue($value, $expectedSchema->items)
             );
+        } elseif ($expectedSchema->type === 'boolean') {
+            $asBool = filter_var($parameterValue, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            return $asBool === null ? $parameterValue : $asBool;
         }
 
         return $parameterValue;

--- a/tests/Fixtures/Boolean.v1.json
+++ b/tests/Fixtures/Boolean.v1.json
@@ -103,44 +103,13 @@
         "operationId": "get-users",
         "parameters": [
           {
-            "name": "page",
+            "name": "boolParam",
             "in": "query",
             "description": "",
-            "example": 1,
+            "example": "true",
             "schema": {
-              "type": "number",
-              "minimum": 1
+              "type": "boolean"
             }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "",
-            "example": 10,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "float_param",
-            "in": "query",
-            "description": "",
-            "example": "4.54",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "in": "query",
-            "name": "order",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "name",
-                "email"
-              ]
-            },
-            "allowEmptyValue": true
           }
         ]
       }

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -489,6 +489,10 @@ class RequestValidatorTest extends TestCase
             ->assertValidationMessage('The data should match one item from enum')
             ->assertInvalidRequest();
 
+        $this->get('/users?order=0')
+            ->assertValidationMessage('The data should match one item from enum')
+            ->assertInvalidRequest();
+
         $this->get('/users?order=')
             ->assertValidRequest();
 
@@ -689,6 +693,57 @@ class RequestValidatorTest extends TestCase
             ->assertStatus(200)
             ->assertValidRequest()
             ->assertValidResponse();
+
+        $this->getJson('/users?page=0&per_page=10&float_param=3.14')
+            ->assertStatus(200)
+            ->assertInvalidRequest()
+            ->assertValidResponse();
+    }
+
+    /**
+     * @dataProvider booleanProvider
+     */
+    public function test_boolean_values($value, $isValid)
+    {
+        Spectator::using('Boolean.v1.json');
+
+        Route::get('/users', function () {
+            return [
+                [
+                    'id' => 1,
+                    'name' => 'Jim',
+                    'email' => 'test@test.test',
+                ],
+            ];
+        })
+            ->middleware(Middleware::class);
+
+        $response = $this->getJson('/users?boolParam='.$value);
+        if ($isValid) {
+            $response->assertValidRequest();
+        } else {
+            $response->assertInvalidRequest();
+        }
+        $response->assertValidResponse(200);
+
+    }
+
+    public static function booleanProvider(): array
+    {
+        return [
+            ['true', true],
+            ['false', true],
+            ['1', true],
+            ['0', true],
+            ['yes', true],
+            ['no', true],
+            ['on', true],
+            ['off', true],
+            ['', true],
+            ['null', false],
+            ['invalid', false],
+
+        ];
     }
 
     public function test_comma_separated_values()


### PR DESCRIPTION
This PR fixes two issues related to request validation.

- If a parameter is not null but "falsey" such as `0` the parameter it is not validated
this PR corrects this and updates the tests

 - It is currently not possible to validate "boolean" type parameters as the assertion will always fail since the string type value from the request parameter is not cast to boolean. `The data (string) must match the type: boolean`
This PR casts `true` and `false` string values only to the appropriate boolean, and adds test coverage