### PR TITLE
Add regex pattern match against the requested url path (#1)

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -46,7 +46,7 @@ class Middleware
         try {
             /** @var \Illuminate\Routing\Route $route */
             $route = $request->route();
-            [$specPath, $pathItem] = $this->pathItem($route, $request->method());
+            [$specPath, $pathItem] = $this->pathItem($route, $request->method(), $request->path());
         } catch (InvalidPathException|MalformedSpecException|MissingSpecException|TypeErrorException|UnresolvableReferenceException $exception) {
             $this->spectator->captureRequestValidation($exception);
             $this->spectator->captureResponseValidation($exception);
@@ -117,7 +117,7 @@ class Middleware
      * @throws IOException
      * @throws InvalidJsonPointerSyntaxException
      */
-    protected function pathItem(Route $route, string $requestMethod): array
+    protected function pathItem(Route $route, string $requestMethod, string $requestUrlPath): array
     {
         $requestPath = Str::start($route->uri(), '/');
 
@@ -142,7 +142,14 @@ class Middleware
 
             if (Str::match($route->getCompiled()->getRegex(), $resolvedPath) !== '') {
                 $pathMatches = true;
-                if (in_array(strtolower($requestMethod), $methods, true)) {
+                $requestUrlPath = '/'.ltrim($requestUrlPath, '/');
+                $regExPattern = preg_replace('/\{[^}]+\}/', '.+', $resolvedPath);
+                $regExPattern = str_replace('/', '\/', $regExPattern);
+
+                $matchedMethod = in_array(strtolower($requestMethod), $methods, true);
+                $matchRequestUrl = preg_match('/^'.$regExPattern.'$/', $requestUrlPath) !== 0;
+
+                if ($matchedMethod && $matchRequestUrl) {
                     $partialMatch = [$resolvedPath, $pathItem];
                 }
             }

--- a/tests/Fixtures/Test.v3.yaml
+++ b/tests/Fixtures/Test.v3.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.0
+info:
+  title: Test.v3
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /cars/electric:
+    patch:
+      summary: Update car charging status
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - charging
+              properties:
+                charging:
+                  type: boolean
+                  description: Update charging status
+                  example: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+
+  /cars/ice:
+    patch:
+      summary: Update car refilling status
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - refill
+              properties:
+                refill:
+                  type: boolean
+                  description: Update refill status
+                  example: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+      
+components:
+  schemas: {}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -903,6 +903,23 @@ class RequestValidatorTest extends TestCase
         $this->getJson('/users/1')
             ->assertValidRequest();
     }
+
+    public function test_static_url_parameter_decoupling(): void
+    {
+        Spectator::using('Test.v3.yaml');
+
+        Route::patch('/cars/{name}', function ($name) {
+            return [
+                'name' => $name,
+            ];
+        })->middleware([SubstituteBindings::class, Middleware::class]);
+
+        $this->patchJson('/cars/electric', ['charging' => true])
+            ->assertValidRequest();
+
+        $this->patchJson('/cars/ice', ['refill' => true])
+            ->assertValidRequest();
+    }
 }
 
 class TestUser extends Model


### PR DESCRIPTION
* Add regex pattern match against the requested url path

This issue came from having static URLs in the API documentation pointing to dynamic URL in my project. 

```
/cars/electric
/cars/ice
```

```
Route::patch('/cars/{name}', function ($name) {
    return [
        'name' => $name,
    ];
});
```

Before this change it will also match with the last defined route in the API documentation, which meant that if the request data was different then the request openAPI validation will fail.

This change will use the route binding regex and the actual request path to find the correct path. Now it will only match the exact match routes if found.