### PR TITLE
fix: Update _ide_helpers.php

### DIFF
--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -8,14 +8,14 @@ namespace Illuminate\Testing {
     /**
      * @see \Spectator\Assertions
      *
-     * @method static assertValidRequest()
-     * @method static assertInvalidRequest()
-     * @method static assertValidResponse($status = null)
-     * @method static assertInvalidResponse($status = null)
-     * @method static assertValidationMessage($expected)
-     * @method static assertErrorsContain($errors)
-     * @method static dumpSpecErrors()
-     * @method static void skipRequestValidation()
+     * @method $this assertValidRequest()
+     * @method $this assertInvalidRequest()
+     * @method $this assertValidResponse($status = null)
+     * @method $this assertInvalidResponse($status = null)
+     * @method $this assertValidationMessage($expected)
+     * @method $this assertErrorsContain($errors)
+     * @method $this assertPathExists()
+     * @method $this dumpSpecErrors()
      */
     class TestResponse
     {


### PR DESCRIPTION
This pull request fixes 3 issues with `_ide_helpers.php`:
- `skipRequestValidation()` doesn't exist
- `assertPathExists()` was missing
- Replacing `static` by `$this` helps IDE autocomplete ([this general problem is better described there](https://youtrack.jetbrains.com/issue/WI-26710/Type-Inference-static-method-doc-type-doesnt-work))