### PR TITLE
Fix route matching where route declares regular expression constraints

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -128,6 +128,9 @@ class Middleware
         $pathMatches = false;
         $partialMatch = null;
 
+        $route->wheres = [];
+        $pathMatchRegex = $route->toSymfonyRoute()->compile()->getRegex();
+
         foreach ($openapi->paths as $path => $pathItem) {
             $resolvedPath = $this->resolvePath($path);
             $methods = array_keys($pathItem->getOperations());
@@ -140,7 +143,7 @@ class Middleware
                 }
             }
 
-            if (Str::match($route->getCompiled()->getRegex(), $resolvedPath) !== '') {
+            if (Str::match($pathMatchRegex, $resolvedPath) !== '') {
                 $pathMatches = true;
                 $requestUrlPath = '/'.ltrim($requestUrlPath, '/');
                 $regExPattern = preg_replace('/\{[^}]+\}/', '.+', $resolvedPath);

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -128,7 +128,10 @@ class RequestValidator extends AbstractValidator
         /** @var \Illuminate\Routing\Route $route */
         $route = $this->request->route();
 
-        preg_match($route->getCompiled()->getRegex(), $this->specPath, $matches);
+        $route->wheres = [];
+        $regex = $route->toSymfonyRoute()->compile()->getRegex();
+
+        preg_match($regex, $this->specPath, $matches);
 
         return Collection::make($matches)
             ->filter(fn (string $value, int|string $key) => is_string($key))

--- a/tests/Fixtures/ParametersNameMismatch.v1.yml
+++ b/tests/Fixtures/ParametersNameMismatch.v1.yml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Global.v1
+  version: '1.0'
+servers:
+  - url: 'https://api.protect.earth/v1'
+    description: Production
+paths:
+  /testing/{id}:
+    get:
+      summary: Get org by int id
+      tags: [ ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+      operationId: get-something
+      parameters:
+        - schema:
+            type: integer
+            format: int64
+          name: id
+          in: path
+          required: true
+components:
+  schemas: {}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -1005,6 +1005,24 @@ class RequestValidatorTest extends TestCase
         $this->patchJson('/cars/ice', ['refill' => true])
             ->assertValidRequest();
     }
+
+    public function test_route_with_parameters_on_name_mismatch_non_string(): void
+    {
+        Config::set('spectator.path_prefix', 'v1');
+
+        Spectator::using('ParametersNameMismatch.v1.yml');
+
+        Route::get('/v1/testing/{idx}', function (int $idx) {
+            return [
+                'id' => $idx,
+                'name' => 'Testing',
+            ];
+        })->whereNumber('idx')->middleware(Middleware::class);
+
+        $this->getJson('/v1/testing/100')
+            ->assertValidRequest()
+            ->assertValidResponse(200);
+    }
 }
 
 class TestUser extends Model


### PR DESCRIPTION
When route is declared with regular expression constraints, the regex failed to match the route when route parameters are different between Laravel and the OpenApi definition.

This PR fixes this

fixes #210 