### PR TITLE
Support comma-separated values in headers

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -102,6 +102,10 @@ class RequestValidator extends AbstractValidator
                     }
                 } elseif ($parameter->in === 'header' && $this->request->headers->has($parameter->name)) {
                     $parameterValue = $this->request->headers->get($parameter->name);
+
+                    if ($parameter->explode === false && $parameter->schema->type === 'array') {
+                        $parameterValue = explode(',', $parameterValue);
+                    }
                 } elseif ($parameter->in === 'cookie' && $this->request->cookies->has($parameter->name)) {
                     $parameterValue = $this->request->cookies->get($parameter->name);
                 }

--- a/tests/Fixtures/CommaSeparatedString.v1.json
+++ b/tests/Fixtures/CommaSeparatedString.v1.json
@@ -115,6 +115,17 @@
                 "enum": ["foo", "bar"]
               }
             }
+          },
+          {
+            "name": "X-Include",
+            "in": "header",
+            "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["foo", "bar"]
+                }
+            }
           }
         ]
       }

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -791,7 +791,9 @@ class RequestValidatorTest extends TestCase
         })
             ->middleware(Middleware::class);
 
-        $this->getJson('/users?include=foo,bar')
+        $this
+            ->withHeader('X-Include', 'foo,bar')
+            ->getJson('/users?include=foo,bar')
             ->assertStatus(200)
             ->assertValidRequest()
             ->assertValidResponse();


### PR DESCRIPTION
If the swagger file says a header should be a comma-separated list, then the validator does not handle that correctly. This PR fixes that.