### PR TITLE
Laravel future proofing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         php: [8.1, 8.2, 8.3, 8.4]
         phpunit: [ '10.*', '11.*']
         include:
@@ -25,6 +25,8 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
           - laravel: 10.*
             phpunit: 11.*
@@ -35,6 +37,10 @@ jobs:
           - laravel: 12.*
             php: 8.1
           - laravel: 12.*
+            phpunit: 10.*
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
             phpunit: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - PU${{ matrix.phpunit }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,8 @@ jobs:
           - laravel: 13.*
             php: 8.1
           - laravel: 13.*
+            php: 8.2
+          - laravel: 13.*
             phpunit: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - PU${{ matrix.phpunit }}

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: "laravel-pint"
         uses: aglipanci/laravel-pint-action@2.3.1
@@ -24,4 +26,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: PHP Linting (Pint)
-          skip_fetch: true
+          skip_fetch: false

--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -5,8 +5,10 @@
 /** @noinspection PhpUnusedAliasInspection */
 
 namespace Illuminate\Testing {
+    use Spectator\Assertions;
+
     /**
-     * @see \Spectator\Assertions
+     * @see Assertions
      *
      * @method $this assertValidRequest()
      * @method $this assertInvalidRequest()

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         "php": "^8.1",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
-        "laravel/framework": "^10.0 | ^11.0 | ^12.0",
+        "laravel/framework": ">=10.0",
         "opis/json-schema": "^2.3"
     },
     "require-dev": {
-        "larastan/larastan": "^2.8|^3.0",
+        "larastan/larastan": ">=2.8",
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^8.0|^9.0 | ^10.0",
-        "phpunit/phpunit": "^10.0|^11.0"
+        "nunomaduro/collision": ">=7.0",
+        "orchestra/testbench": ">=8.0",
+        "phpunit/phpunit": ">=10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -6,6 +6,7 @@ use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
 use Closure;
 use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\ExpectationFailedException;
 use Spectator\Concerns\HasExpectations;
@@ -16,7 +17,7 @@ use Spectator\Exceptions\RequestValidationException;
 use Spectator\Exceptions\ResponseValidationException;
 
 /**
- * @mixin \Illuminate\Testing\TestResponse
+ * @mixin TestResponse
  */
 class Assertions
 {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -44,7 +44,7 @@ class Middleware
         }
 
         try {
-            /** @var \Illuminate\Routing\Route $route */
+            /** @var Route $route */
             $route = $request->route();
             [$specPath, $pathItem] = $this->pathItem($route, $request->method(), $request->path());
         } catch (InvalidPathException|MalformedSpecException|MissingSpecException|TypeErrorException|UnresolvableReferenceException $exception) {

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -2,7 +2,10 @@
 
 namespace Spectator;
 
+use cebe\openapi\exceptions\IOException;
 use cebe\openapi\exceptions\TypeErrorException;
+use cebe\openapi\exceptions\UnresolvableReferenceException;
+use cebe\openapi\json\InvalidJsonPointerSyntaxException;
 use cebe\openapi\Reader;
 use cebe\openapi\spec\OpenApi;
 use Illuminate\Support\Arr;
@@ -24,7 +27,7 @@ class RequestFactory
 
     protected ?string $pathPrefix = null;
 
-    /** @var array<string, \cebe\openapi\spec\OpenApi> */
+    /** @var array<string, OpenApi> */
     private static array $cachedSpecs = [];
 
     /**
@@ -78,9 +81,9 @@ class RequestFactory
      * Resolve and parse the spec.
      *
      *
-     * @throws \cebe\openapi\exceptions\IOException
-     * @throws \cebe\openapi\exceptions\UnresolvableReferenceException
-     * @throws \cebe\openapi\json\InvalidJsonPointerSyntaxException
+     * @throws IOException
+     * @throws UnresolvableReferenceException
+     * @throws InvalidJsonPointerSyntaxException
      * @throws MalformedSpecException
      * @throws MissingSpecException
      */

--- a/src/Spectator.php
+++ b/src/Spectator.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \stdClass resolve() Resolve the spec into an object.
  * @method bool shouldValidateRequest() Indicate if request should be validated.
  *
- * @see \Spectator\RequestFactory
+ * @see RequestFactory
  */
 class Spectator extends Facade
 {

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -7,6 +7,7 @@ use cebe\openapi\spec\PathItem;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Opis\JsonSchema\Validator;
@@ -55,7 +56,7 @@ class RequestValidator extends AbstractValidator
      */
     protected function validateParameters(): void
     {
-        /** @var \Illuminate\Routing\Route $route */
+        /** @var Route $route */
         $route = $this->request->route();
 
         $parameters = array_merge(
@@ -125,7 +126,7 @@ class RequestValidator extends AbstractValidator
 
     protected function translateParameterName(string $parameter): string
     {
-        /** @var \Illuminate\Routing\Route $route */
+        /** @var Route $route */
         $route = $this->request->route();
 
         $route->wheres = [];
@@ -234,7 +235,7 @@ class RequestValidator extends AbstractValidator
     }
 
     /**
-     * @return ($data is array<string, mixed> ? \stdClass : ($data is array<int, mixed> ? array<int, mixed> : mixed))
+     * @return ($data is array<string, mixed> ? stdClass : ($data is array<int, mixed> ? array<int, mixed> : mixed))
      */
     private function toObject(mixed $data): mixed
     {

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -881,7 +881,7 @@ class ResponseValidatorTest extends TestCase
 
         Route::get('/', fn () => 'ok')->middleware(Middleware::class);
 
-        $this->expectException(\ErrorException::class);
+        $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('The spec file is invalid. Please lint it using spectral (https://github.com/stoplightio/spectral) before trying again.');
 
         $this->getJson('/')


### PR DESCRIPTION
 ## Laravel future-proofing
 
 Rather than appending each new Laravel major version to an ever-growing list of constraints, this PR switches to open lower-bound (`>=`) version constraints so that Laravel 13, 14, and beyond are supported automatically without requiring a `composer.json` update on every release.
 
 ### Changes
 
 **`composer.json`**
 - `laravel/framework`: `^10.0 | ^11.0 | ^12.0` → `>=10.0`
 - `orchestra/testbench`: `^8.0|^9.0 | ^10.0` → `>=8.0`
 - `nunomaduro/collision`: `^7.0|^8.0` → `>=7.0`
 - `larastan/larastan`: `^2.8|^3.0` → `>=2.8`
 - `phpunit/phpunit`: `^10.0|^11.0` → `>=10.0`
 
 **`.github/workflows/tests.yml`**
 - Adds Laravel 13 to the test matrix with `orchestra/testbench: 11.*`
 - Excludes PHP 8.1 and PHPUnit 10 for Laravel 13 (matching the same pattern as Laravel 11/12)
 
 ### Why this approach
 
The alternative (PR #217, generated by Laravel Shift) manually appends `^13.0` to each constraint — but that requires the same update again when Laravel 14 ships. Using `>=` constraints means the package declares compatibility with all current and future versions from the minimum supported baseline, with CI covering the explicitly tested matrix.
 
 Closes #217