### PR TITLE
Fix: objects without properties, and arrays without items

### DIFF
--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -257,8 +257,10 @@ abstract class SchemaValidationException extends \Exception implements Exception
                         $schemaMap[$locationCurrent] = self::indentedDisplayString($displayString, $indentLevel);
 
                         // create entry for array's items
-                        $nextSchema = $schema['items'];
-                        $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent.'/items', '', [], ++$indentLevel));
+                        if (isset($schema['items'])) {
+                            $nextSchema = $schema['items'];
+                            $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent.'/items', '', [], ++$indentLevel));
+                        }
 
                         break;
                     default:

--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -239,13 +239,15 @@ abstract class SchemaValidationException extends \Exception implements Exception
                         );
                         $schemaMap[$locationCurrent] = self::indentedDisplayString($displayString, $indentLevel);
 
-                        // create entries for all object properties
-                        $indentLevel = ++$indentLevel;
-                        foreach ($schema['properties'] as $key => $nextSchema) {
-                            if (isset($schema['required'])) {
-                                $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent, $key, $schema['required'], $indentLevel));
-                            } else {
-                                $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent, $key, [], $indentLevel));
+                        if (isset($schema['properties'])) {
+                            // create entries for all object properties
+                            $indentLevel = ++$indentLevel;
+                            foreach ($schema['properties'] as $key => $nextSchema) {
+                                if (isset($schema['required'])) {
+                                    $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent, $key, $schema['required'], $indentLevel));
+                                } else {
+                                    $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent, $key, [], $indentLevel));
+                                }
                             }
                         }
                         break;

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -1018,6 +1018,29 @@ class ResponseValidatorTest extends TestCase
         $this->assertSame(['#' => 'object++'], $schemaMap);
     }
 
+    public function test_supports_array_schema_without_items(): void
+    {
+        $previousErrorReporting = error_reporting(E_ALL);
+        set_error_handler(static function (int $severity, string $message, string $file, int $line): void {
+            throw new ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $schemaMap = ResponseValidationException::formatSchema(
+                ['type' => 'array'],
+                '#',
+                '',
+                [],
+                0
+            );
+        } finally {
+            restore_error_handler();
+            error_reporting($previousErrorReporting);
+        }
+
+        $this->assertSame(['#' => 'array'], $schemaMap);
+    }
+
     #[DataProvider('arrayOfStringsProvider')]
     public function test_array_of_strings(mixed $payload, bool $isValid): void
     {

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -7,6 +7,8 @@ use Exception;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Spectator\Exceptions\ResponseValidationException;
 use Spectator\Middleware;
 use Spectator\Spectator;
 use Spectator\SpectatorServiceProvider;
@@ -41,9 +43,7 @@ class ResponseValidatorTest extends TestCase
             ->assertValidResponse();
     }
 
-    /**
-     * @dataProvider streamedContentTypeProvider
-     */
+    #[DataProvider('streamedContentTypeProvider')]
     public function test_returns_streamed_response(string $contentType, bool $valid): void
     {
         Spectator::using('ContentType.yml');
@@ -383,9 +383,7 @@ class ResponseValidatorTest extends TestCase
         $this->fail('Failed asserting an exception was thrown');
     }
 
-    /**
-     * @dataProvider nullableProvider
-     */
+    #[DataProvider('nullableProvider')]
     public function test_handle_nullables($version, $state, $isValid): void
     {
         Spectator::using("Nullable.$version.json");
@@ -528,9 +526,7 @@ class ResponseValidatorTest extends TestCase
             ->assertValidResponse();
     }
 
-    /**
-     * @dataProvider nullableArrayOfNullableStringsProvider
-     */
+    #[DataProvider('nullableArrayOfNullableStringsProvider')]
     public function test_nullable_array_of_nullable_strings($version, $payload, $isValid): void
     {
         Spectator::using("Nullable.$version.json");
@@ -602,9 +598,7 @@ class ResponseValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider oneOfSchemaProvider
-     */
+    #[DataProvider('oneOfSchemaProvider')]
     // https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
     public function test_handles_one_of($response, $valid): void
     {
@@ -667,9 +661,7 @@ class ResponseValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider anyOfSchemaProvider
-     */
+    #[DataProvider('anyOfSchemaProvider')]
     // https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
     public function test_handles_any_of($response, $isValid): void
     {
@@ -729,9 +721,7 @@ class ResponseValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider allOfSchemaProvider
-     */
+    #[DataProvider('allOfSchemaProvider')]
     // https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
     public function test_handles_all_of($response, $isValid): void
     {
@@ -801,9 +791,7 @@ class ResponseValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider allOfWithNullableProvider
-     */
+    #[DataProvider('allOfWithNullableProvider')]
     public function test_handles_all_of_with_nullable($payload, $isValid): void
     {
         Spectator::using('AllOf.v1.yml');
@@ -1009,9 +997,28 @@ class ResponseValidatorTest extends TestCase
             ]);
     }
 
-    /**
-     * @dataProvider arrayOfStringsProvider
-     */
+    public function test_supports_object_schema_without_properties(): void
+    {
+        set_error_handler(static function (int $severity, string $message, string $file, int $line): void {
+            throw new ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $schemaMap = ResponseValidationException::formatSchema(
+                ['type' => 'object'],
+                '#',
+                '',
+                [],
+                0
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(['#' => 'object++'], $schemaMap);
+    }
+
+    #[DataProvider('arrayOfStringsProvider')]
     public function test_array_of_strings(mixed $payload, bool $isValid): void
     {
         Spectator::using('Arrays.v1.yml');
@@ -1064,9 +1071,7 @@ class ResponseValidatorTest extends TestCase
         $response->assertValidResponse();
     }
 
-    /**
-     * @dataProvider requiredWriteOnlySchemaProvider
-     */
+    #[DataProvider('requiredWriteOnlySchemaProvider')]
     public function test_required_writeonly(
         $payload,
         $is_valid
@@ -1138,9 +1143,7 @@ class ResponseValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider objectAsDictionaryProvider
-     */
+    #[DataProvider('objectAsDictionaryProvider')]
     public function test_object_as_dictionary(mixed $payload, bool $isValid): void
     {
         Spectator::using('Dictionary.v1.yml');
@@ -1180,9 +1183,7 @@ class ResponseValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider nullableObjectAsDictionaryProvider
-     */
+    #[DataProvider('nullableObjectAsDictionaryProvider')]
     public function test_nullable_object_as_dictionary(mixed $payload, bool $isValid): void
     {
         Spectator::using('Dictionary.v1.yml');


### PR DESCRIPTION
Hey @hotmeteor! 👋🏻 

Doing some odd jobs for a client and they were patching this fix in via composer patches, so I'm hoisting it back upstream. 

Gone with red/green testing here and made the test first. Pushed it up but here it is:
```
 FAILED  Spectator\Tests\ResponseValidatorTest > supports object schema without properties                                                                                               ErrorException
  Undefined array key "properties"

  at src/Exceptions/SchemaValidationException.php:245
    241▕
    242▕                         // if (isset($schema['properties'])) {
    243▕                             // create entries for all object properties
    244▕                             $indentLevel = ++$indentLevel;
  ➜ 245▕                             foreach ($schema['properties'] as $key => $nextSchema) {
    246▕                                 if (isset($schema['required'])) {
    247▕                                     $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent, $key, $schema['required'], $indentLevel));
    248▕                                 } else {
    249▕                                     $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent, $key, [], $indentLevel));

  1   src/Exceptions/SchemaValidationException.php:245
  2   tests/ResponseValidatorTest.php:1007


  Tests:    1 failed, 77 passed (187 assertions)
  Duration: 0.80s
```

Basically any object might not have properties for any reason. Maybe its additionalProperties only for a simple example.

There's also a second and related error, arrays might not have items.

```
   FAILED  Spectator\Tests\ResponseValidatorTest > supports array schema without…   ErrorException
  Undefined array key "items"

  at src/Exceptions/SchemaValidationException.php:261
    257▕                         $schemaMap[$locationCurrent] = self::indentedDisplayString($displayString, $indentLevel);
    258▕
    259▕                         // create entry for array's items
    260▕                         // if (isset($schema['items'])) {
  ➜ 261▕                             $nextSchema = $schema['items'];
    262▕                             $schemaMap = array_merge($schemaMap, self::formatSchema($nextSchema, $locationCurrent.'/items', '', [], ++$indentLevel));
    263▕                         // }
    264▕
    265▕                         break;

  1   src/Exceptions/SchemaValidationException.php:261
  2   tests/ResponseValidatorTest.php:1029
```

Arrays absolutely do not have to define an `items` property and could use dynamic options like `additionalItems` or `prefixItems` instead.

This pull request fixes both of these things, so if you wouldn't mind a quick merge and a 2.2.1 that would help me out a lot. 