### PR TITLE
V3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 Spectator is a Laravel package that provides OpenAPI contract testing tools. It validates that HTTP requests and responses conform to an OpenAPI spec, complementing (not replacing) Laravel's functional tests.
 
+**Requirements: PHP 8.3+, Laravel 12+**
+
 ## Commands
 
 ```bash
@@ -22,13 +24,16 @@ vendor/bin/phpunit --filter test_validates_request_body tests/RequestValidatorTe
 The package is built around a middleware-driven validation loop:
 
 1. **`Spectator` facade** — thin facade over `RequestFactory` (singleton).
-2. **`RequestFactory`** — holds the active spec name, path prefix, and captured exceptions (`requestException`, `responseException`). Parses and caches spec files. Uses the `Macroable` trait for extensibility.
+2. **`RequestFactory`** — holds the active spec name, path prefix, and captured exceptions (`requestException`, `responseException`). Parses and caches spec files. Uses the `Macroable` trait for extensibility. Key methods: `using()`, `reset()`, `withPathPrefix()` / `setPathPrefix()`, `useJsonErrors()` / `useTextErrors()`.
 3. **`Middleware`** — prepended to the `api` middleware group. On each request it resolves the spec, matches the route to a `PathItem`, then calls `RequestValidator` and `ResponseValidator`. Exceptions from validators are *captured* into `RequestFactory` (not thrown), allowing assertions to run after the response is returned.
 4. **`RequestValidator` / `ResponseValidator`** — both extend `AbstractValidator`, which handles:
    - OpenAPI 3.0 → 3.1 `nullable` migration (converts `nullable: true` to `type: [T, null]` internally)
    - `readOnly`/`writeOnly` property filtering based on read/write mode
+   - `runValidation()` is defined on `AbstractValidator` and called by both subclasses
 5. **`Assertions`** — mixed into `TestResponse` via `TestResponse::mixin(new Assertions)`. Each method returns a `Closure` (the mixin pattern). Assertions read the captured exceptions from `app('spectator')`.
-6. **`SpectatorServiceProvider`** — registers the singleton, merges config, but only registers middleware and the `TestResponse` mixin when `App::runningInConsole()` (i.e., during tests).
+6. **`SpectatorServiceProvider`** — registers the singleton, merges config, but only registers middleware and the `TestResponse` mixin when `App::runningInConsole()` (i.e., during tests). Also registers artisan commands inside this guard.
+7. **`Console/ValidateSpecCommand`** — `spectator:validate --spec=<file> [--format=json]`. Validates that a spec file parses without errors.
+8. **`Console/CoverageCommand`** — `spectator:coverage --spec=<file> [--format=json]`. Lists every operation (method + path) defined in the spec.
 
 ## Key Conventions
 
@@ -39,6 +44,12 @@ The package is built around a middleware-driven validation loop:
 - Spec fixtures live in `tests/Fixtures/` and are loaded via `SPEC_PATH=./tests/Fixtures` (set in `phpunit.xml`).
 - Test method names use `snake_case` prefixed with `test_` (e.g., `test_validates_request_body`).
 
+### Console command tests
+- Use Laravel's `$this->artisan(...)` with `expectsOutputToContain()` — one assertion per `artisan()` chain.
+- **Do not** use `expectsOutput()` with multi-line strings; it matches a single `doWrite` call and will fail.
+- JSON output uses `foreach (explode(PHP_EOL, json_encode(..., JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) as $line) { $this->line($line); }` so each line is a separate `doWrite` call.
+- Command helper methods must not be named `fail()` — `Illuminate\Console\Command` already declares `fail()`.
+
 ### Spec fixtures
 - Named like `FeatureName.v1.yml` or `FeatureName.v1.json`.
 - Called in tests with `Spectator::using('FeatureName.v1.yml')`.
@@ -47,13 +58,23 @@ The package is built around a middleware-driven validation loop:
 ### Validation exceptions
 - `RequestValidationException` and `ResponseValidationException` extend `SchemaValidationException`.
 - Validators call `static::withError($message, $result->error())` to construct exceptions with structured error info.
+- `SchemaValidationException::validationErrorMessage()` checks `config('spectator.error_format')`: when `'json'`, returns `{"errors": [...]}` JSON; otherwise renders annotated ANSI text.
 - Assertions check exception type via `expectsTrue`/`expectsFalse` (in `HasExpectations` trait).
+
+### Enums (v3+)
+Internal constants are now proper PHP enums:
+- `SpecSource` — `Local`, `Remote`, `Github` (spec source types)
+- `ValidationMode` — `Request`, `Response` (used in `AbstractValidator`)
+- `Format` — `Text`, `Json` (console output format; string-backed, used by commands)
+
+### Error format
+`config('spectator.error_format')` defaults to `'text'`. Set to `'json'` via `SPECTATOR_ERROR_FORMAT=json` or `Spectator::useJsonErrors()`. `RequestFactory::reset()` does **not** reset this — it is config-driven and survives within a test. Orchestra Testbench provides a fresh app per test, so there's no cross-test leakage.
 
 ### Spec caching
 `RequestFactory` caches parsed specs in a static `$cachedSpecs` array keyed by file path. If you change a fixture file during a test run, the cache won't be invalidated.
 
 ### Path prefix
-When the API is mounted under a prefix (e.g., `/v1`), set `spectator.path_prefix` in config or call `Spectator::setPathPrefix('v1')`. The middleware strips the prefix before matching against spec paths.
+When the API is mounted under a prefix (e.g., `/v1`), set `spectator.path_prefix` in config or call `Spectator::withPathPrefix('v1')` (fluent alias for `setPathPrefix()`). The middleware strips the prefix before matching against spec paths.
 
 ### OpenAPI version handling
 The middleware sets `$version` from `$openapi->openapi` after resolving the spec. This version string is passed to validators to handle 3.0 vs 3.1 differences (primarily `nullable` semantics).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,10 @@ The package is built around a middleware-driven validation loop:
 6. **`SpectatorServiceProvider`** — registers the singleton, merges config, but only registers middleware and the `TestResponse` mixin when `App::runningInConsole()` (i.e., during tests). Also registers artisan commands inside this guard.
 7. **`Console/ValidateSpecCommand`** — `spectator:validate --spec=<file> [--format=json]`. Validates that a spec file parses without errors.
 8. **`Console/CoverageCommand`** — `spectator:coverage --spec=<file> [--format=json]`. Lists every operation (method + path) defined in the spec.
+9. **`Console/RoutesCommand`** — `spectator:routes --spec=<file> [--format=json]`. Cross-references spec operations against registered Laravel routes (matched / unimplemented / undocumented). Uses `Route::getRoutes()->getRoutes()` for PHPStan-safe iteration.
+10. **`Console/StubsCommand`** — `spectator:stubs --spec=<file> [--output] [--namespace] [--base-class] [--force]`. Generates skeleton test classes from a spec. **Path handling note:** uses `str_starts_with($output, DIRECTORY_SEPARATOR)` to detect absolute paths and use them as-is; otherwise resolves relative to `base_path()`.
+11. **`Coverage/CoverageTracker`** — static process-level registry (`array<string, true>` set semantics) that records which spec operations are exercised. `recordSpec()` is idempotent (guarded with `isset()`). Called from `Middleware`: `recordSpec()` in `pathItem()`, `record()` in `validate()` before validators run.
+12. **`Coverage/SpectatorExtension`** — PHPUnit 11 `Extension` implementation. Subscribes to `ExecutionFinished` via anonymous class. Reads `CoverageTracker::getBySpec()`, prints coverage table. `min_coverage` parameter uses `register_shutdown_function(fn () => exit(1))` to override PHPUnit's exit code for CI failure (direct exit from `ExecutionFinished` subscriber is not supported by PHPUnit).
 
 ## Key Conventions
 
@@ -49,6 +53,13 @@ The package is built around a middleware-driven validation loop:
 - **Do not** use `expectsOutput()` with multi-line strings; it matches a single `doWrite` call and will fail.
 - JSON output uses `foreach (explode(PHP_EOL, json_encode(..., JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) as $line) { $this->line($line); }` so each line is a separate `doWrite` call.
 - Command helper methods must not be named `fail()` — `Illuminate\Console\Command` already declares `fail()`.
+- `RoutesCommand` and `StubsCommand` tests register inline routes with `Route::get(...)` inside the test method before calling `$this->artisan(...)`.
+- `StubsCommand` tests use `sys_get_temp_dir().'/spectator-stubs-test-'.uniqid()` as `--output` (absolute path). The command detects absolute paths via `str_starts_with($output, DIRECTORY_SEPARATOR)` and uses them as-is.
+
+### Coverage tracking
+- `CoverageTracker` is a **process-level static registry** — data accumulates across all test methods in a PHPUnit run. Never call `CoverageTracker::reset()` in `tearDown()`; only call it in unit tests that need isolation or at suite start.
+- The tracker uses `array<string, true>` set semantics (not append-only arrays) to prevent double-counting. Keys are `"METHOD /path"` strings.
+- `SpectatorExtension` subscribes to `ExecutionFinished` (not `RunFinished`). To fail the PHPUnit process when `min_coverage` is not met, use `register_shutdown_function(static fn () => exit(1))` — this overrides PHPUnit's own exit code since PHPUnit calls `exit()` after all subscribers run.
 
 ### Spec fixtures
 - Named like `FeatureName.v1.yml` or `FeatureName.v1.json`.

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,6 +6,11 @@ on:
       - '**.php'
       - 'phpstan.neon.dist'
       - '.github/workflows/phpstan.yml'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
 
 jobs:
   phpstan:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,37 +15,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: ['10.*', '11.*', '12.*', '13.*']
-        php: [8.1, 8.2, 8.3, 8.4]
-        phpunit: [ '10.*', '11.*']
+        laravel: ['12.*']
+        php: [8.3, 8.4]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 13.*
-            testbench: 11.*
-        exclude:
-          - laravel: 10.*
-            phpunit: 11.*
-          - laravel: 10.*
-            php: 8.4
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
-          - laravel: 12.*
-            phpunit: 10.*
-          - laravel: 13.*
-            php: 8.1
-          - laravel: 13.*
-            php: 8.2
-          - laravel: 13.*
-            phpunit: 10.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - PU${{ matrix.phpunit }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - uses: actions/checkout@v4
@@ -63,8 +39,8 @@ jobs:
       - name: Install dependencies
         run: |
           composer remove --dev laravel/pint --no-interaction --no-update
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
-          composer update --prefer-dist --no-progress --no-suggest
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --prefer-dist --no-progress
 
       - name: Run test suite
         run: composer run-script test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: ['12.*']
+        laravel: ['12.*', '13.*']
         php: [8.3, 8.4]
         include:
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -2,360 +2,356 @@
 
 # Spectator
 
-Spectator provides light-weight OpenAPI testing tools you can use within your existing Laravel test suite.
+Spectator provides light-weight OpenAPI contract testing tools that work within your existing Laravel test suite.
 
-Write tests that verify your API spec doesn't drift from your implementation.
+Write tests that guarantee your API spec never drifts from your implementation.
 
 ![Tests](https://github.com/hotmeteor/spectator/workflows/Tests/badge.svg)
 [![Latest Version on Packagist](https://img.shields.io/packagist/vpre/hotmeteor/spectator.svg?style=flat-square)](https://packagist.org/packages/hotmeteor/spectator)
 ![PHP from Packagist](https://img.shields.io/packagist/php-v/hotmeteor/spectator)
 
+---
+
 ## Requirements
 
-- PHP 8.1+
-- Laravel 10+
+- PHP 8.3+
+- Laravel 12+
+
+---
 
 ## Installation
-
-You can install the package through Composer.
 
 ```bash
 composer require hotmeteor/spectator --dev
 ```
 
-Then, publish the config file of this package with this command:
+Publish the config file:
 
 ```bash
 php artisan vendor:publish --provider="Spectator\SpectatorServiceProvider"
 ```
 
-The config file will be published in `config/spectator.php`.
-
-### Upgrading from v1 to v2
-
-**Important:** Spectator v2 requires PHP 8.1 and Laravel 10. If you are using an older version of PHP or Laravel, you should not upgrade to v2.
-
-While this should typically be a straightforward upgrade, you should be aware of some of the changes that have been made.
-
-Please read the [UPGRADE.md](UPGRADE.md) file for more information.
+---
 
 ## Configuration
 
-### Sources
+The published config lives at `config/spectator.php`. The most important setting is the spec **source**, which tells Spectator where to find your OpenAPI spec files.
 
-**Sources** are references to where your API spec lives. Depending on the way you or your team works, or where your spec lives, you may want to configure different sources for different environments.
+### Local
 
-As you can see from the config, there's three source types available: `local`, `remote`, and `github`. Each source requires the folder where your spec lives to be defined, not the spec file itself. This provides flexibility when working with multiple APIs in one project, or an API fragmented across multiple spec files.
-
----
-
-#### Local
+Specs are read from the local filesystem.
 
 ```env
-## Spectator config
-
 SPEC_SOURCE=local
-SPEC_PATH=/spec/reference
+SPEC_PATH=/path/to/specs
 ```
 
----
+### Remote
 
-#### Remote
-
-_This is using the raw access link from Github, but any remote source can be specified. The SPEC_URL_PARAMS can be used to append any additional parameters required for the remote url._
+Specs are fetched over HTTP. Useful for remote-hosted specs or raw GitHub file URLs.
 
 ```env
-## Spectator config
-
-SPEC_PATH="https://raw.githubusercontent.com/path/to/repo"
-SPEC_URL_PARAMS="?token=ABEDC3E5AQ3HMUBPPCDTTMDAFPMSM"
+SPEC_SOURCE=remote
+SPEC_PATH=https://raw.githubusercontent.com/org/repo/main/specs
+SPEC_URL_PARAMS="?token=abc123"   # optional query params appended to the URL
 ```
 
----
+### GitHub
 
-#### Github
-
-_This uses the Github Personal Access Token which allows you access to a remote repo containing your contract._
-
-You can view instructions on how to obtain your Personal Access Token from Github at [this link](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) .
-
-**Important to note than the SPEC_GITHUB_PATH must included the branch (ex: main) and then the path to the directory containing your contract.**
+Specs are fetched from a private GitHub repository using a Personal Access Token.
 
 ```env
-## Spectator config
+SPEC_SOURCE=github
+SPEC_GITHUB_REPO=org/repo
+SPEC_GITHUB_PATH=main/specs       # branch + path to the directory
+SPEC_GITHUB_TOKEN=ghp_yourtoken
+```
 
-SPEC_GITHUB_PATH='main/contracts'
-SPEC_GITHUB_REPO='orgOruser/repo'
-SPEC_GITHUB_TOKEN='your personal access token'
+### Path Prefix
+
+If your API is mounted under a prefix (e.g. `/v1`), configure it here so Spectator strips it before matching spec paths.
+
+```env
+SPECTATOR_PATH_PREFIX=v1
+```
+
+Or set it at runtime:
+
+```php
+Spectator::withPathPrefix('v1');
+```
+
+### Error Format
+
+By default, validation errors are rendered as human-readable, coloured terminal output. For CI pipelines and LLM toolchains that parse test output programmatically, switch to JSON:
+
+```env
+SPECTATOR_ERROR_FORMAT=json
+```
+
+Or toggle it per test:
+
+```php
+Spectator::useJsonErrors();   // emit {"errors": [...]}
+Spectator::useTextErrors();   // revert to coloured text
 ```
 
 ---
 
-### Specifying the Target Spec File
+## Writing Contract Tests
 
-In your tests you will declare the spec file you want to test against:
+### What contract testing is
 
-```php
-public function testBasicExample()
-{
-    Spectator::using('Api.v1.json');
+**Functional tests** verify that your application behaves correctly — validation passes, controllers respond, events fire.
 
-    // ...
-```
+**Contract tests** verify that your requests and responses conform to your OpenAPI spec. The data doesn't have to be real; the shape does.
 
-## Testing
+The two test types complement each other. Keep them in separate test classes.
 
-### Paradigm Shift
+### Pointing to a spec
 
-**Now, on to the good stuff.**
-
-At first, spec testing, or contract testing, may seem counter-intuitive, especially when compared with "feature" or "functional" testing as supported by Laravel's [HTTP Tests](https://laravel.com/docs/8.x/http-tests). 
-
-While _functional_ tests are ensuring that your request validation, controller behavior, events, responses, etc. all behave the way you expect when people interact with your API, _contract_ tests are ensuring that **requests and responses are spec-compliant** - _and that's it_. The data itself could be wrong, but that's outside the scope of a contract test.
-
-### Writing Tests
-
-Spectator introduces a few simple tools to compliment the existing Laravel testing toolbox.
-
-Here's an example of a typical JSON API test:
+Call `Spectator::using()` with the spec filename before making any requests. You can call it once in `setUp()` or per test.
 
 ```php
-<?php
-
-class ExampleTest extends TestCase
-{
-    /**
-     * A basic functional test example.
-     *
-     * @return void
-     */
-    public function testBasicExample()
-    {
-        $response = $this->postJson('/user', ['name' => 'Sally']);
-
-        $response
-            ->assertStatus(201)
-            ->assertJson([
-                'created' => true,
-            ]);
-    }
-}
-```
-
-And here's an example of a contract test:
-
-```php
-<?php
-
 use Spectator\Spectator;
 
-class ExampleTest extends TestCase
+class UserApiTest extends TestCase
 {
-    /**
-     * A basic functional test example.
-     *
-     * @return void
-     */
-    public function testBasicExample()
-    {
-        Spectator::using('Api.v1.json');
-
-        $response = $this->postJson('/user', ['name' => 'Sally']);
-
-        $response
-            ->assertValidRequest()
-            ->assertValidResponse(201);
-    }
-}
-```
-
-The test is verifying that both the request and the response are valid according to the spec, in this case located in `Api.v1.json`. This type of testing promotes TDD: you can write endpoint contract tests against your endpoints _first_, and then ensure your spec and implementation are aligned.
-
-Within your spec, each possible response should be documented. For example, a single `POST` endpoint may result in a `2xx`, `4xx`, or even `5xx` code response. Additionally, your endpoints will likely have particular parameter validation that needs to be adhered to. 
-
-This is what makes contract testing different from functional testing:
-
-- in **functional testing**, successful and failed responses are tested for outcomes
-- in **contract testing**, requests and responses are tested for conformity and outcomes don't matter.
-
-### Debugging
-
-For certain validation errors, a special exception message is thrown which shows error message(s) displayed alongside the expected schema. For example:
-
-```
-  ---
-
-The properties must match schema: data
-All array items must match schema
-The required properties (name) are missing
-
-object++ <== The properties must match schema: data
-    status*: string
-    data*: array <== All array items must match schema
-        object <== The required properties (name) are missing
-            id*: string
-            name*: string
-            slug: string?
-
-  ---
-```
-
-A few custom symbols are used:
-
-- "++": Object supports `additionalProperties`
-- "\*": Item is `required`
-- "?": Item can be `nullable`
-
-## Usage
-
-### Providing a Spec
-
-Define the spec file to test against. This can be defined in your `setUp()` method or in a specific test method.
-
-```php
-<?php
-
-use Spectator\Spectator;
-
-class ExampleTest extends TestCase
-{
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
-        Spectator::using('Api.v1.json');
+        Spectator::using('Api.v1.yml');
     }
 
-    public function testApiEndpoint()
+    #[Test]
+    public function test_using_different_spec(): void
     {
-        // Test request and response...
-    }
-
-    public function testDifferentApiEndpoint()
-    {
-        Spectator::using('Other.v1.json');
-
-        // Test request and response...
+        Spectator::using('OtherApi.v1.yml');
+        // ...
     }
 }
 ```
 
-### Testing Requests
+### Making assertions
 
-When testing endpoints, there are a few new methods:
+Spectator adds these methods to Laravel's `TestResponse`:
+
+| Method | Description |
+|---|---|
+| `assertValidRequest()` | Assert the request matches the spec. |
+| `assertInvalidRequest()` | Assert the request does **not** match the spec. |
+| `assertValidResponse(?int $status)` | Assert the response matches the spec (optionally at a specific status code). |
+| `assertInvalidResponse(?int $status)` | Assert the response does **not** match the spec. |
+| `assertValidationMessage(string $message)` | Assert the validation error message contains the given string. |
+| `assertErrorsContain(string\|array $errors)` | Assert one or more strings appear in the validation errors. |
+| `assertPathExists()` | Assert the requested path exists in the spec. |
+| `dumpSpecErrors()` | Dump current spec errors without failing (useful for debugging). |
+
+### A typical contract test
 
 ```php
-$this->assertValidRequest();
-$this->assertValidResponse($status = null);
-$this->assertValidationMessage('Expected validation message');
-$this->assertErrorsContain('Check for single error');
-$this->assertErrorsContain(['Check for', 'Multiple Errors']);
+use Spectator\Spectator;
+
+class UserApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Spectator::using('Api.v1.yml');
+    }
+
+    #[Test]
+    public function test_create_user(): void
+    {
+        $this->postJson('/users', ['name' => 'Alice', 'email' => 'alice@example.com'])
+            ->assertValidRequest()
+            ->assertValidResponse(201);
+    }
+
+    #[Test]
+    public function test_missing_required_field_is_invalid(): void
+    {
+        $this->postJson('/users', ['name' => 'Alice'])   // missing email
+            ->assertInvalidRequest()
+            ->assertValidationMessage('required');
+    }
+}
 ```
 
-Of course, you can continue to use all existing HTTP test methods:
+### Mixing with functional tests
+
+You can chain Spectator assertions with Laravel's built-in assertions, but keeping concerns separate is cleaner:
 
 ```php
-$this
-    ->actingAs($user)
-    ->postJson('/comments', [
-        'message' => 'Just over here spectating',
-    ])
+// Works, but mixes concerns
+$this->actingAs($user)
+    ->postJson('/posts', ['title' => 'Hello'])
     ->assertCreated()
-    ->assertValidRequest()
-    ->assertValidResponse();
-```
-
-That said, mixing functional and contract testing may become more difficult to manage and read later. It's strongly advised to keep the two types of tests separate.
-
-### Testing Responses
-
-Instead of using the built-in `->assertStatus($status)` method, you may also verify the response that is valid is actually the response you want to check. For example, you may receive a `200` **or** a `202` from a single endpoint, and you want to ensure you're validating the correct response.
-
-```php
-$this
-    ->actingAs($user)
-    ->postJson('/comments', [
-        'message' => 'Just over here spectating',
-    ])
     ->assertValidRequest()
     ->assertValidResponse(201);
 ```
 
-When exceptions are thrown that are not specific to this package's purpose, e.g. typos or missing imports, the output will be formatted by default with a rather short message and no stack trace.
-This can be changed by disabling Laravel's built-in validation handler which allows for easier debugging when running tests.
-
-This can be done in a few different ways:
+### Deactivating Spectator for a test
 
 ```php
-class ExampleTestCase
+Spectator::reset();
+```
+
+### Debugging errors
+
+When a validation fails, Spectator renders the schema with errors annotated inline:
+
+```
+---
+
+The properties must match schema: data
+
+object++ <== The properties must match schema: data
+    status*: string
+    data*: array
+        object <== The required properties (name) are missing
+            id*: string
+            name*: string
+            email: string?
+
+---
+```
+
+Symbol legend:
+- `++` — object allows `additionalProperties`
+- `*` — property is `required`
+- `?` — property is `nullable`
+
+Use `dumpSpecErrors()` to inspect errors without failing the test:
+
+```php
+$this->postJson('/users', $payload)
+    ->dumpSpecErrors()
+    ->assertValidRequest();
+```
+
+---
+
+## Artisan Commands
+
+### `spectator:validate`
+
+Validate that a spec file parses without errors. Useful as a pre-test lint gate in CI.
+
+```bash
+php artisan spectator:validate --spec=Api.v1.yml
+php artisan spectator:validate --spec=Api.v1.yml --format=json
+```
+
+Text output:
+
+```
+✔ Api.v1.yml is valid.
+```
+
+JSON output (`--format=json`):
+
+```json
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        Spectator::using('Api.v1.json');
-
-        // Disable exception handling for all tests in this file
-        $this->withoutExceptionHandling();
-    }
-
-    // ...
+    "valid": true,
+    "spec": "Api.v1.yml",
+    "errors": []
 }
 ```
 
-```php
-class ExampleTestCase
+Returns exit code `0` on success, `1` on failure.
+
+### `spectator:coverage`
+
+List every operation defined in the spec. Useful for auditing coverage gaps.
+
+```bash
+php artisan spectator:coverage --spec=Api.v1.yml
+php artisan spectator:coverage --spec=Api.v1.yml --format=json
+```
+
+Text output:
+
+```
+Operations in Api.v1.yml:
+
+ ────── ─────────────── 
+  GET    /users
+  POST   /users
+  GET    /users/{id}
+ ────── ─────────────── 
+
+3 operations
+```
+
+JSON output (`--format=json`):
+
+```json
 {
-    public function test_some_contract_test_example(): void
-    {
-        // Only disable exception handling for this test
-        $this->withouthExceptionHandling();
-
-        // Test request and response ...
-
-    }
+    "spec": "Api.v1.yml",
+    "operations": [
+        { "method": "GET", "path": "/users" },
+        { "method": "POST", "path": "/users" },
+        { "method": "GET", "path": "/users/{id}" }
+    ]
 }
 ```
 
-### Deactivating Spectator
+---
 
-If you want to deactivate Spectator for a specific test, you can use the `Spectator::reset` method:
+## CI & AI Integration
 
-```php
-<?php
+### Validating specs in CI
 
-use Spectator\Spectator;
+Add `spectator:validate` as an early CI step to catch malformed specs before tests run:
 
-class ExampleTest extends TestCase
+```yaml
+# GitHub Actions example
+- name: Validate OpenAPI spec
+  run: php artisan spectator:validate --spec=Api.v1.yml --format=json
+```
+
+### Machine-readable error output
+
+Set `SPECTATOR_ERROR_FORMAT=json` in your CI environment to make validation errors parseable by log aggregators and LLM agents:
+
+```env
+SPECTATOR_ERROR_FORMAT=json
+```
+
+With this setting, a failed assertion produces a JSON error body instead of ANSI-coloured text:
+
+```json
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        Spectator::using('Api.v1.json');
-    }
-
-    public function testWithoutSpectator()
-    {
-        Spectator::reset();
-        
-        // Run your test without Spectator
-    }
+    "errors": [
+        "The data (null) must match the type: string"
+    ]
 }
 ```
+
+### Feeding errors to an LLM
+
+The JSON error format is designed for toolchains that analyse test output programmatically. Parse `{"errors": [...]}` from test output and pass it directly to your LLM workflow for root-cause analysis or spec repair suggestions.
+
+---
+
+## Upgrading
+
+Please read [UPGRADE.md](UPGRADE.md) for a full list of breaking changes between versions.
+
+---
 
 ## Core Concepts
 
-### Approach
+Spectator registers a middleware that intercepts every test request, matches it against the loaded spec's `PathItem`, and validates both the request and the response. Captured exceptions are stored on the `RequestFactory` singleton so assertions can read them after the response is returned.
 
-Spectator works by registering a custom middleware that performs request and response validation against a spec.
+### Key dependencies
 
-### Dependencies
+- [`cebe/php-openapi`](https://github.com/cebe/php-openapi) — parses OpenAPI 3.x specs into typed objects
+- [`opis/json-schema`](https://github.com/opis/json-schema) — validates request/response data against JSON Schema
 
-For those interested in contributing to Spectator, it is worth familiarizing yourself with the core dependencies used for spec testing:
-
-- `cebe/php-openapi`: Used to parse specs into usable arrays
-- `opis/json-schema`: Used to perform validation of an object/array against a spec
+---
 
 ## Sponsors
 
@@ -370,8 +366,8 @@ If you'd like to become a sponsor, please [see here for more information](https:
 - Inspired by [Laravel OpenAPI](https://github.com/mdwheele/laravel-openapi) package by [Dustin Wheeler](https://github.com/mdwheele)
 - [All Contributors](../../contributors)
 
-<a href = "https://github.com/hotmeteor/spectator/graphs/contributors">
-  <img src = "https://contrib.rocks/image?repo=hotmeteor/spectator"/>
+<a href="https://github.com/hotmeteor/spectator/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=hotmeteor/spectator"/>
 </a>
 
 Made with [contributors-img](https://contrib.rocks).
@@ -379,3 +375,4 @@ Made with [contributors-img](https://contrib.rocks).
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Write tests that guarantee your API spec never drifts from your implementation.
 ## What's New in v3
 
 - **PHP 8.3+ and Laravel 12+** — minimum requirements raised to track the modern PHP ecosystem.
-- **New artisan commands** — `spectator:validate` lints your spec file; `spectator:coverage` lists every operation defined in the spec. Both support `--format=json` for machine-readable output.
+- **New artisan commands** — `spectator:validate` lints your spec file; `spectator:coverage` lists every operation defined in the spec; `spectator:routes` cross-references spec operations against Laravel routes; `spectator:stubs` generates skeleton test classes from a spec. All commands support `--format=json` for machine-readable output.
+- **PHPUnit coverage extension** — `SpectatorExtension` tracks which spec operations are exercised during a test run and can enforce a minimum coverage threshold in CI.
 - **Machine-readable JSON errors** — set `SPECTATOR_ERROR_FORMAT=json` (or call `Spectator::useJsonErrors()`) to get structured `{"errors": [...]}` output from failed assertions instead of ANSI-coloured text.
 - **Modern PHP internals** — enums replace string/class constants; first-class callables, `readonly` properties, and `match` expressions throughout.
 - **Remote & GitHub spec sources verified** — remote HTTP and private GitHub spec fetching work reliably out of the box.
@@ -309,6 +310,82 @@ JSON output (`--format=json`):
 }
 ```
 
+### `spectator:routes`
+
+Cross-references spec operations against registered Laravel routes. Surfaces which operations are matched, which are missing from the app, and which routes have no spec entry.
+
+```bash
+php artisan spectator:routes --spec=Api.v1.yml
+php artisan spectator:routes --spec=Api.v1.yml --format=json
+```
+
+Text output:
+
+```
+Routes in Api.v1.yml:
+
+ ──────── ──────── ─────────────────── 
+  Status   Method   Path
+ ──────── ──────── ─────────────────── 
+  ✔        GET      /users
+  ✔        POST     /users
+  ✗        DELETE   /users/{id}
+  ⚠        GET      /internal
+ ──────── ──────── ─────────────────── 
+
+Matched: 2  |  Unimplemented: 1  |  Undocumented: 1
+```
+
+- `✔ matched` — in spec and a Laravel route exists
+- `✗ unimplemented` — in spec, no matching Laravel route
+- `⚠ undocumented` — Laravel route exists, not in spec
+
+### `spectator:stubs`
+
+Generates skeleton test classes from a spec. Groups operations by tag (fallback: first path segment) and creates one class per group with one `test_` method per operation. Each method body calls `$this->markTestIncomplete(...)` so the generated file is immediately runnable.
+
+```bash
+php artisan spectator:stubs --spec=Api.v1.yml
+php artisan spectator:stubs --spec=Api.v1.yml --output=tests/Contract --namespace="Tests\\Contract"
+php artisan spectator:stubs --spec=Api.v1.yml --force
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--spec` | — | Spec filename (required). |
+| `--output` | `tests/Contract` | Directory to write generated classes to. |
+| `--namespace` | `Tests\Contract` | PHP namespace for generated classes. |
+| `--base-class` | `Tests\TestCase` | Parent class for generated test classes. |
+| `--force` | `false` | Overwrite existing files. |
+
+Example generated class:
+
+```php
+namespace Tests\Contract;
+
+use Spectator\Spectator;
+use Tests\TestCase;
+
+class UsersContractTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Spectator::using('Api.v1.yml');
+    }
+
+    public function test_get_users(): void
+    {
+        $this->markTestIncomplete('Implement: GET /users');
+    }
+
+    public function test_post_users(): void
+    {
+        $this->markTestIncomplete('Implement: POST /users');
+    }
+}
+```
+
 ---
 
 ## CI & AI Integration
@@ -344,6 +421,36 @@ With this setting, a failed assertion produces a JSON error body instead of ANSI
 ### Feeding errors to an LLM
 
 The JSON error format is designed for toolchains that analyse test output programmatically. Parse `{"errors": [...]}` from test output and pass it directly to your LLM workflow for root-cause analysis or spec repair suggestions.
+
+### Contract coverage tracking
+
+`SpectatorExtension` is a PHPUnit 11 extension that tracks which spec operations are exercised during a test run and prints a coverage summary when the suite finishes.
+
+Enable it in `phpunit.xml`:
+
+```xml
+<extensions>
+    <bootstrap class="Spectator\Coverage\SpectatorExtension">
+        <!-- Fail the suite if coverage drops below 80% -->
+        <parameter name="min_coverage" value="80"/>
+        <!-- Optional: json | text (default: text) -->
+        <parameter name="format" value="text"/>
+    </bootstrap>
+</extensions>
+```
+
+Example output at suite end:
+
+```
+Spectator Coverage
+──────────────────────────────────────────
+ Spec          Operations   Covered   %
+──────────────────────────────────────────
+ Api.v1.yml    6            5         83%
+──────────────────────────────────────────
+```
+
+When `min_coverage` is set and not met, the extension causes PHPUnit to exit with code `1`, failing the CI job.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Write tests that guarantee your API spec never drifts from your implementation.
 
 ---
 
+## What's New in v3
+
+- **PHP 8.3+ and Laravel 12+** — minimum requirements raised to track the modern PHP ecosystem.
+- **New artisan commands** — `spectator:validate` lints your spec file; `spectator:coverage` lists every operation defined in the spec. Both support `--format=json` for machine-readable output.
+- **Machine-readable JSON errors** — set `SPECTATOR_ERROR_FORMAT=json` (or call `Spectator::useJsonErrors()`) to get structured `{"errors": [...]}` output from failed assertions instead of ANSI-coloured text.
+- **Modern PHP internals** — enums replace string/class constants; first-class callables, `readonly` properties, and `match` expressions throughout.
+- **Remote & GitHub spec sources verified** — remote HTTP and private GitHub spec fetching work reliably out of the box.
+- **Fluent path-prefix API** — `Spectator::withPathPrefix('v1')` as an alternative to the config key.
+
+---
+
 ## Requirements
 
 - PHP 8.3+

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,77 @@
 # Upgrading
 
+## From v2 to v3
+
+### Breaking changes
+
+**Minimum requirements raised**
+- PHP 8.3+ required (was 8.1+)
+- Laravel 12+ required (was 10+)
+
+**New config key**
+A new `error_format` key has been added to `config/spectator.php`. If you published the config in v2, add the following:
+
+```php
+'error_format' => env('SPECTATOR_ERROR_FORMAT', 'text'),
+```
+
+No behaviour change unless you set `SPECTATOR_ERROR_FORMAT=json` or call `Spectator::useJsonErrors()`.
+
+**Internal enum types (extenders only)**
+If you extend Spectator's validator classes, the following internal types have changed:
+
+| Before | After |
+|---|---|
+| `'read'` / `'write'` string in `AbstractValidator` | `ValidationMode::Read` / `ValidationMode::Write` enum cases |
+| `Format::TEXT_GREEN` etc. class constants | `Format::TextGreen` etc. string-backed enum cases |
+
+These are internal implementation details. If you only use the public facade and test assertions, no changes are required.
+
+---
+
 ## From v1 to v2
+
+While this should be a pretty easy upgrade, you should be aware of some of the changes that have been made.
+
+- Minimum PHP version is now 8.1 and minimum Laravel version is now 10.
+- The configuration slightly changed. Check the [configuration](config/spectator.php) and update your configuration
+  accordingly.
+- Calling `$response->assertValidRequest()` now fails if the openapi spec is not found or invalid, which was not the
+  case previously.
+- The specification must now be found and valid when calling `$response->assertInvalidRequest()`
+  or `$response->assertInvalidResponse()`.
+  
+  Previously, the request or response was considered invalid if the spec was not found or invalid,
+  thus `$response->assertInvalidRequest()` or `$response->assertInvalidResponse()` did pass.
+  It will now fail.
+- The `$response->assertInvalidRequest()` and `$response->assertInvalidResponse()` previously did not fail if called on
+  a perfectly valid http call. It will now fail.
+- When providing a http code to `$response->assertValidResponse($code)` or `$response->assertInvalidResponse($code)`, we
+  now prioritize the validation of the actual http code over the validation of the specification.
+- Spectator now ignores the charset definition in the `Content-Type` header of the response in order to find the 
+  response definition in the openapi. If you previously defined your openapi with the full `Content-Type` header, you will have to delete the charset part.
+  ```diff
+  /users:
+    get:
+      summary: Get users
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+  -         application/json; charset=utf-8:
+  +         application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+  ```
+- The validation is stricter than before. Tests that were passing before might now fail. You may need to update your
+  tests or your openapi specifications.
+- A non-empty response body will be now considered invalid against a specification not defining a response content.
+- Internal modifications were made. If you extend Spectator, you may need to update your code.
+
 
 While this should be a pretty easy upgrade, you should be aware of some of the changes that have been made.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,17 @@ If you extend Spectator's validator classes, the following internal types have c
 
 These are internal implementation details. If you only use the public facade and test assertions, no changes are required.
 
+### New features (additive, no action required)
+
+The following are new capabilities added in v3. They do not change existing behaviour.
+
+- **`spectator:validate`** — lints a spec file from the CLI.
+- **`spectator:coverage`** — lists all operations defined in a spec.
+- **`spectator:routes`** — cross-references spec operations against Laravel routes.
+- **`spectator:stubs`** — generates skeleton test classes from a spec.
+- **`SpectatorExtension`** — PHPUnit 11 extension for end-of-run coverage reporting. Opt in via `phpunit.xml`.
+- **JSON error format** — `SPECTATOR_ERROR_FORMAT=json` or `Spectator::useJsonErrors()`.
+
 ---
 
 ## From v1 to v2

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         "php": "^8.3",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
-        "laravel/framework": "^12.0",
+        "laravel/framework": ">=12.0",
         "opis/json-schema": "^2.3"
     },
     "require-dev": {
-        "larastan/larastan": "^3.0",
+        "larastan/larastan": ">=3.0",
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^10.0",
+        "nunomaduro/collision": ">=8.0",
+        "orchestra/testbench": ">=10.0",
         "phpunit/phpunit": "^11.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
-        "laravel/framework": ">=10.0",
+        "laravel/framework": "^12.0",
         "opis/json-schema": "^2.3"
     },
     "require-dev": {
-        "larastan/larastan": ">=2.8",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": ">=7.0",
-        "orchestra/testbench": ">=8.0",
-        "phpunit/phpunit": ">=10.0"
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^10.0",
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         },
         "laravel": {
             "providers": [

--- a/config/spectator.php
+++ b/config/spectator.php
@@ -57,7 +57,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Middleware Groups
+    | Error Format
+    |--------------------------------------------------------------------------
+    |
+    | Controls the format of schema validation error messages in test output.
+    | Use 'text' (default) for human-readable coloured terminal output, or
+    | 'json' for machine-readable output suited to CI log parsers and LLMs.
+    |
+    | You can also call Spectator::useJsonErrors() / useTextErrors() per-test.
+    |
+    */
+
+    'error_format' => env('SPECTATOR_ERROR_FORMAT', 'text'),
+
+    /*
     |--------------------------------------------------------------------------
     |
     | Specify the groups that spectator's middleware should be prepended to.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         backupGlobals="false"         
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         backupGlobals="false"
          colors="true"
          processIsolation="false"
-         stopOnFailure="false"         
+         stopOnFailure="false"
 >
     <testsuites>
         <testsuite name="default">

--- a/src/Console/CoverageCommand.php
+++ b/src/Console/CoverageCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Spectator\Console;
+
+use Illuminate\Console\Command;
+use Spectator\Exceptions\MalformedSpecException;
+use Spectator\Exceptions\MissingSpecException;
+use Spectator\RequestFactory;
+use Throwable;
+
+class CoverageCommand extends Command
+{
+    protected $signature = 'spectator:coverage
+                            {--spec= : Spec file name (e.g. Api.v1.yml)}
+                            {--format=text : Output format: text or json}';
+
+    protected $description = 'List all operations defined in your OpenAPI spec.';
+
+    public function handle(RequestFactory $factory): int
+    {
+        $spec = $this->option('spec');
+        $format = $this->option('format');
+
+        if ($spec) {
+            $factory->using($spec);
+        }
+
+        $specName = $factory->getSpec();
+
+        if (! $specName) {
+            $this->error('No spec file specified. Use --spec= or call Spectator::using() in your test.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $openapi = $factory->resolve();
+        } catch (MissingSpecException|MalformedSpecException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        } catch (Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $operations = [];
+
+        foreach ($openapi->paths as $path => $pathItem) {
+            foreach (['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as $method) {
+                if ($pathItem->{$method} !== null) {
+                    $operations[] = [
+                        'method' => strtoupper($method),
+                        'path' => $path,
+                        'operationId' => $pathItem->{$method}->operationId ?? null,
+                        'summary' => $pathItem->{$method}->summary ?? null,
+                    ];
+                }
+            }
+        }
+
+        if ($format === 'json') {
+            foreach (explode(PHP_EOL, json_encode([
+                'spec' => $specName,
+                'operations' => $operations,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) as $line) {
+                $this->line($line);
+            }
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Operations in {$specName}:");
+        $this->newLine();
+
+        $this->table(
+            headers: ['Method', 'Path', 'Operation ID', 'Summary'],
+            rows: array_map(
+                fn (array $op) => [$op['method'], $op['path'], $op['operationId'] ?? '—', $op['summary'] ?? '—'],
+                $operations,
+            ),
+        );
+
+        $this->newLine();
+        $this->line(count($operations).' operation(s) found.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/RoutesCommand.php
+++ b/src/Console/RoutesCommand.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Spectator\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Illuminate\Support\Str;
+use Spectator\Exceptions\MalformedSpecException;
+use Spectator\Exceptions\MissingSpecException;
+use Spectator\RequestFactory;
+use Throwable;
+
+class RoutesCommand extends Command
+{
+    protected $signature = 'spectator:routes
+                            {--spec= : Spec file name (e.g. Api.v1.yml)}
+                            {--format=text : Output format: text or json}';
+
+    protected $description = 'Compare spec operations against registered Laravel routes.';
+
+    public function handle(RequestFactory $factory): int
+    {
+        $spec = $this->option('spec');
+        $format = $this->option('format');
+
+        if ($spec) {
+            $factory->using($spec);
+        }
+
+        $specName = $factory->getSpec();
+
+        if (! $specName) {
+            $this->error('No spec file specified. Use --spec= or call Spectator::using() in your test.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $openapi = $factory->resolve();
+        } catch (MissingSpecException|MalformedSpecException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        } catch (Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        // Build a normalised set of all Laravel route keys: "METHOD /path/{_}"
+        $laravelRoutes = $this->collectLaravelRoutes();
+
+        // Enumerate spec operations
+        $specOps = [];
+        foreach ($openapi->paths as $path => $pathItem) {
+            foreach (['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as $method) {
+                if ($pathItem->{$method} !== null) {
+                    // Prepend the configured path prefix so the resolved path matches the
+                    // actual Laravel route URI (e.g. "/api/users" not "/users").
+                    $resolvedPath = $this->resolvePath($path, $factory->getPathPrefix());
+                    $normalised = strtoupper($method).' '.$this->normalizePath($resolvedPath);
+                    $specOps[] = [
+                        'method' => strtoupper($method),
+                        'path' => $path,
+                        'resolved' => $resolvedPath,
+                        'normalised' => $normalised,
+                        'matched' => isset($laravelRoutes[$normalised]),
+                    ];
+                }
+            }
+        }
+
+        // Find undocumented routes: Laravel routes with no matching spec operation
+        $specNormalised = array_column($specOps, 'normalised');
+        $undocumented = [];
+        foreach ($laravelRoutes as $routeKey => $uri) {
+            if (! in_array($routeKey, $specNormalised, true)) {
+                $undocumented[] = $routeKey;
+            }
+        }
+        sort($undocumented);
+
+        if ($format === 'json') {
+            return $this->outputJson($specName, $specOps, $undocumented);
+        }
+
+        return $this->outputText($specName, $specOps, $undocumented);
+    }
+
+    /**
+     * Collect all registered Laravel routes as a normalised map.
+     * Key: "METHOD /normalised/path/{_}"
+     * Value: the original URI for display.
+     *
+     * @return array<string, string>
+     */
+    private function collectLaravelRoutes(): array
+    {
+        $routes = [];
+
+        /** @var Route $route */
+        foreach (RouteFacade::getRoutes()->getRoutes() as $route) {
+            $uri = Str::start($route->uri(), '/');
+
+            foreach ($route->methods() as $method) {
+                // Laravel adds HEAD for every GET — skip to avoid duplicates
+                if ($method === 'HEAD') {
+                    continue;
+                }
+
+                $key = strtoupper($method).' '.$this->normalizePath($uri);
+                $routes[$key] = $uri;
+            }
+        }
+
+        return $routes;
+    }
+
+    /**
+     * Normalise a path by replacing all route parameters with {_} so that
+     * positional comparison is possible regardless of parameter names.
+     *
+     * Handles both required {param} and optional {param?} variants.
+     */
+    private function normalizePath(string $path): string
+    {
+        return preg_replace('/\{[^}]+\}/', '{_}', $path) ?? $path;
+    }
+
+    /**
+     * Prepend the spectator path prefix to a spec path, mirroring Middleware::resolvePath().
+     */
+    private function resolvePath(string $path, string $prefix): string
+    {
+        $separator = '/';
+
+        $parts = array_filter(array_map(
+            fn (string $part) => trim($part, $separator),
+            [$prefix, $path],
+        ));
+
+        return $separator.implode($separator, $parts);
+    }
+
+    /**
+     * @param  array<array{method: string, path: string, resolved: string, normalised: string, matched: bool}>  $specOps
+     * @param  array<string>  $undocumented
+     */
+    private function outputText(string $specName, array $specOps, array $undocumented): int
+    {
+        $this->info("Route comparison for {$specName}:");
+        $this->newLine();
+
+        $rows = [];
+
+        foreach ($specOps as $op) {
+            $rows[] = [
+                $op['matched'] ? '<fg=green>matched</>' : '<fg=red>unimplemented</>',
+                $op['method'],
+                $op['path'],
+            ];
+        }
+
+        foreach ($undocumented as $key) {
+            [$method, $path] = explode(' ', $key, 2);
+            $rows[] = ['<fg=yellow>undocumented</>', $method, $path];
+        }
+
+        $this->table(['Status', 'Method', 'Path'], $rows);
+
+        $matched = count(array_filter($specOps, fn ($op) => $op['matched']));
+        $unimplemented = count($specOps) - $matched;
+
+        $this->newLine();
+        $this->line(sprintf(
+            '%d matched, %d unimplemented, %d undocumented.',
+            $matched,
+            $unimplemented,
+            count($undocumented),
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<array{method: string, path: string, resolved: string, normalised: string, matched: bool}>  $specOps
+     * @param  array<string>  $undocumented
+     */
+    private function outputJson(string $specName, array $specOps, array $undocumented): int
+    {
+        $payload = [
+            'spec' => $specName,
+            'spec_operations' => array_map(fn ($op) => [
+                'method' => $op['method'],
+                'path' => $op['path'],
+                'status' => $op['matched'] ? 'matched' : 'unimplemented',
+            ], $specOps),
+            'undocumented_routes' => array_values(array_map(function (string $key) {
+                [$method, $path] = explode(' ', $key, 2);
+
+                return ['method' => $method, 'path' => $path];
+            }, $undocumented)),
+        ];
+
+        foreach (explode(PHP_EOL, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) as $line) {
+            $this->line($line);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/StubsCommand.php
+++ b/src/Console/StubsCommand.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Spectator\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Spectator\Exceptions\MalformedSpecException;
+use Spectator\Exceptions\MissingSpecException;
+use Spectator\RequestFactory;
+use Throwable;
+
+class StubsCommand extends Command
+{
+    protected $signature = 'spectator:stubs
+                            {--spec= : Spec file name (e.g. Api.v1.yml)}
+                            {--output=tests/Contract : Directory to write generated test classes (relative to base path)}
+                            {--namespace=Tests\\Contract : Namespace for generated test classes}
+                            {--base-class=Tests\\TestCase : Fully-qualified base test class}
+                            {--force : Overwrite existing files}';
+
+    protected $description = 'Generate skeleton contract test classes from an OpenAPI spec.';
+
+    public function handle(RequestFactory $factory): int
+    {
+        $spec = $this->option('spec');
+        $output = $this->option('output');
+        $namespace = $this->option('namespace');
+        $baseClass = $this->option('base-class');
+        $force = (bool) $this->option('force');
+
+        if ($spec) {
+            $factory->using($spec);
+        }
+
+        $specName = $factory->getSpec();
+
+        if (! $specName) {
+            $this->error('No spec file specified. Use --spec= or call Spectator::using() in your test.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $openapi = $factory->resolve();
+        } catch (MissingSpecException|MalformedSpecException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        } catch (Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        // Collect and group all operations
+        $groups = [];
+        foreach ($openapi->paths as $path => $pathItem) {
+            foreach (['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as $method) {
+                $operation = $pathItem->{$method};
+                if ($operation === null) {
+                    continue;
+                }
+
+                $group = $this->resolveGroup($path, (array) ($operation->tags ?? []));
+
+                $groups[$group][] = [
+                    'method' => strtoupper($method),
+                    'path' => $path,
+                    'operationId' => $operation->operationId ?? null,
+                    'summary' => $operation->summary ?? null,
+                ];
+            }
+        }
+
+        if (empty($groups)) {
+            $this->warn("No operations found in {$specName}.");
+
+            return self::SUCCESS;
+        }
+
+        $outputPath = str_starts_with($output, DIRECTORY_SEPARATOR) || (strlen($output) > 1 && $output[1] === ':')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists($outputPath);
+
+        $written = 0;
+        $skipped = 0;
+
+        foreach ($groups as $group => $ops) {
+            $className = Str::studly($group).'ContractTest';
+            $filePath = $outputPath.DIRECTORY_SEPARATOR.$className.'.php';
+
+            if (File::exists($filePath) && ! $force) {
+                $this->line("  <fg=yellow>SKIP</>  {$className}.php (already exists, use --force to overwrite)");
+                $skipped++;
+
+                continue;
+            }
+
+            $content = $this->generateClass($specName, $className, $ops, $namespace, $baseClass);
+            File::put($filePath, $content);
+
+            $this->line("  <fg=green>WRITE</> {$className}.php");
+            $written++;
+        }
+
+        $this->newLine();
+        $this->line("{$written} file(s) written, {$skipped} skipped.");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolve the group name for an operation.
+     * Uses the first tag when available; falls back to the first non-parameter path segment.
+     *
+     * @param  array<string>  $tags
+     */
+    private function resolveGroup(string $path, array $tags): string
+    {
+        if (! empty($tags)) {
+            return (string) $tags[0];
+        }
+
+        // Walk the path segments and use the first one that is not a route parameter
+        $segments = array_filter(explode('/', ltrim($path, '/')));
+        foreach ($segments as $segment) {
+            if (! Str::startsWith($segment, '{')) {
+                return $segment;
+            }
+        }
+
+        return 'misc';
+    }
+
+    /**
+     * Derive a unique test method name for the operation.
+     * Prefers operationId (converted to snake_case); falls back to method+path slug.
+     *
+     * @param  array<string>  &$used
+     */
+    private function methodName(string $method, string $path, ?string $operationId, array &$used): string
+    {
+        if ($operationId !== null && $operationId !== '') {
+            $base = 'test_'.Str::snake(str_replace(['-', ' ', '.'], '_', $operationId));
+        } else {
+            $pathSlug = (string) preg_replace('/_+/', '_', (string) preg_replace('/[^a-z0-9]/', '_', strtolower($path)));
+            $base = 'test_'.strtolower($method).'_'.trim($pathSlug, '_');
+        }
+
+        // Ensure uniqueness within the class
+        $name = $base;
+        $suffix = 2;
+        while (in_array($name, $used, true)) {
+            $name = $base.'_'.$suffix++;
+        }
+
+        $used[] = $name;
+
+        return $name;
+    }
+
+    /**
+     * Generate a PHP test class as a string.
+     *
+     * @param  array<array{method: string, path: string, operationId: ?string, summary: ?string}>  $ops
+     */
+    private function generateClass(
+        string $specName,
+        string $className,
+        array $ops,
+        string $namespace,
+        string $baseClass,
+    ): string {
+        $baseShort = str_contains($baseClass, '\\') ? Str::afterLast($baseClass, '\\') : $baseClass;
+        $baseUse = str_contains($baseClass, '\\') ? "use {$baseClass};\n" : '';
+
+        $usedNames = [];
+        $methodBlocks = [];
+
+        foreach ($ops as $op) {
+            $name = $this->methodName($op['method'], $op['path'], $op['operationId'], $usedNames);
+            $label = "{$op['method']} {$op['path']}";
+            $docComment = $op['summary'] !== null ? "    /** {$op['summary']} */\n" : '';
+
+            $methodBlocks[] = <<<PHP
+{$docComment}    public function {$name}(): void
+    {
+        \$this->markTestIncomplete('Implement: {$label}');
+    }
+PHP;
+        }
+
+        $methods = implode("\n\n", $methodBlocks);
+
+        return <<<PHP
+<?php
+
+namespace {$namespace};
+
+use Spectator\Middleware;
+use Spectator\Spectator;
+{$baseUse}
+class {$className} extends {$baseShort}
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Spectator::using('{$specName}');
+    }
+
+{$methods}
+}
+PHP;
+    }
+}

--- a/src/Console/ValidateSpecCommand.php
+++ b/src/Console/ValidateSpecCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Spectator\Console;
+
+use Illuminate\Console\Command;
+use Spectator\Exceptions\MalformedSpecException;
+use Spectator\Exceptions\MissingSpecException;
+use Spectator\RequestFactory;
+use Throwable;
+
+class ValidateSpecCommand extends Command
+{
+    protected $signature = 'spectator:validate
+                            {--spec= : Spec file name (e.g. Api.v1.yml)}
+                            {--format=text : Output format: text or json}';
+
+    protected $description = 'Validate that your OpenAPI spec parses without errors.';
+
+    public function handle(RequestFactory $factory): int
+    {
+        $spec = $this->option('spec');
+        $format = $this->option('format');
+
+        if ($spec) {
+            $factory->using($spec);
+        }
+
+        $specName = $factory->getSpec();
+
+        if (! $specName) {
+            return $this->outputFailure(
+                format: $format,
+                spec: null,
+                message: 'No spec file specified. Use --spec= or call Spectator::using() in your test.',
+            );
+        }
+
+        try {
+            $factory->resolve();
+        } catch (MissingSpecException|MalformedSpecException $e) {
+            return $this->outputFailure(format: $format, spec: $specName, message: $e->getMessage());
+        } catch (Throwable $e) {
+            return $this->outputFailure(format: $format, spec: $specName, message: $e->getMessage());
+        }
+
+        return $this->outputSuccess(format: $format, spec: $specName);
+    }
+
+    private function outputSuccess(string $format, string $spec): int
+    {
+        if ($format === 'json') {
+            foreach (explode(PHP_EOL, json_encode(['valid' => true, 'spec' => $spec, 'errors' => []], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) as $line) {
+                $this->line($line);
+            }
+        } else {
+            $this->info("✔ {$spec} is valid.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function outputFailure(string $format, ?string $spec, string $message): int
+    {
+        if ($format === 'json') {
+            foreach (explode(PHP_EOL, json_encode(['valid' => false, 'spec' => $spec, 'errors' => [$message]], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) as $line) {
+                $this->line($line);
+            }
+        } else {
+            $this->error('✘ '.($spec ?? 'Unknown spec').": {$message}");
+        }
+
+        return self::FAILURE;
+    }
+}

--- a/src/Coverage/CoverageTracker.php
+++ b/src/Coverage/CoverageTracker.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Spectator\Coverage;
+
+/**
+ * Process-level registry that accumulates spec operations and records which ones
+ * are exercised by the test suite. Uses associative set semantics so duplicate
+ * recordings are idempotent.
+ */
+final class CoverageTracker
+{
+    /** @var array<string, array<string, true>> */
+    private static array $specOps = [];
+
+    /** @var array<string, array<string, true>> */
+    private static array $coveredOps = [];
+
+    /**
+     * Register all operations for a spec (no-op if already registered).
+     *
+     * @param  array<array{method: string, path: string}>  $ops
+     */
+    public static function recordSpec(string $spec, array $ops): void
+    {
+        if (isset(self::$specOps[$spec])) {
+            return;
+        }
+
+        self::$specOps[$spec] = [];
+
+        foreach ($ops as $op) {
+            $key = strtoupper($op['method']).' '.$op['path'];
+            self::$specOps[$spec][$key] = true;
+        }
+    }
+
+    /**
+     * Mark a spec operation as covered by the running test.
+     */
+    public static function record(string $spec, string $method, string $path): void
+    {
+        $key = strtoupper($method).' '.$path;
+        self::$coveredOps[$spec][$key] = true;
+    }
+
+    /**
+     * Return coverage data keyed by spec name.
+     *
+     * @return array<string, array{total: int, covered: int, percent: float, operations: array<array{key: string, covered: bool}>}>
+     */
+    public static function getBySpec(): array
+    {
+        $result = [];
+
+        foreach (self::$specOps as $spec => $ops) {
+            $coveredOps = self::$coveredOps[$spec] ?? [];
+            $total = count($ops);
+            $coveredCount = count(array_intersect_key($ops, $coveredOps));
+
+            $operations = [];
+            foreach (array_keys($ops) as $key) {
+                $operations[] = [
+                    'key' => $key,
+                    'covered' => isset($coveredOps[$key]),
+                ];
+            }
+
+            $result[$spec] = [
+                'total' => $total,
+                'covered' => $coveredCount,
+                'percent' => $total > 0 ? round(($coveredCount / $total) * 100, 1) : 0.0,
+                'operations' => $operations,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Clear all accumulated data. Only call this at suite start or in unit tests.
+     */
+    public static function reset(): void
+    {
+        self::$specOps = [];
+        self::$coveredOps = [];
+    }
+}

--- a/src/Coverage/SpectatorExtension.php
+++ b/src/Coverage/SpectatorExtension.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spectator\Coverage;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+/**
+ * PHPUnit 11 extension that reports Spectator spec coverage after the test run.
+ *
+ * Register in phpunit.xml:
+ *
+ *   <extensions>
+ *       <bootstrap class="Spectator\Coverage\SpectatorExtension">
+ *           <parameter name="min_coverage" value="80"/>
+ *           <parameter name="format" value="text"/>
+ *       </bootstrap>
+ *   </extensions>
+ *
+ * Parameters:
+ *   min_coverage  Integer 0-100. If actual coverage falls below this value the
+ *                 test run exits with a non-zero code (CI failure). Default: 0.
+ *   format        "text" (default) or "json".
+ */
+final class SpectatorExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $minCoverage = $parameters->has('min_coverage') ? (int) $parameters->get('min_coverage') : 0;
+        $format = $parameters->has('format') ? $parameters->get('format') : 'text';
+
+        $facade->registerSubscriber(
+            new class($minCoverage, $format) implements ExecutionFinishedSubscriber
+            {
+                public function __construct(
+                    private readonly int $minCoverage,
+                    private readonly string $format,
+                ) {}
+
+                public function notify(ExecutionFinished $event): void
+                {
+                    $bySpec = CoverageTracker::getBySpec();
+
+                    if (empty($bySpec)) {
+                        return;
+                    }
+
+                    if ($this->format === 'json') {
+                        echo json_encode($bySpec, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL;
+
+                        return;
+                    }
+
+                    $this->printTable($bySpec);
+                }
+
+                /**
+                 * @param  array<string, array{total: int, covered: int, percent: float, operations: array<array{key: string, covered: bool}>}>  $bySpec
+                 */
+                private function printTable(array $bySpec): void
+                {
+                    $belowThreshold = false;
+
+                    echo PHP_EOL.'Spectator Coverage'.PHP_EOL;
+                    echo str_repeat('─', 60).PHP_EOL;
+
+                    foreach ($bySpec as $spec => $data) {
+                        echo PHP_EOL."  {$spec}: {$data['covered']}/{$data['total']} ({$data['percent']}%)".PHP_EOL;
+
+                        foreach ($data['operations'] as $op) {
+                            $mark = $op['covered'] ? '  ✔' : '  ✗';
+                            echo "{$mark}  {$op['key']}".PHP_EOL;
+                        }
+
+                        if ($this->minCoverage > 0 && $data['percent'] < $this->minCoverage) {
+                            $belowThreshold = true;
+                            echo PHP_EOL."  ⚠ Coverage {$data['percent']}% is below the minimum {$this->minCoverage}%".PHP_EOL;
+                        }
+                    }
+
+                    echo PHP_EOL;
+
+                    if ($belowThreshold) {
+                        register_shutdown_function(static fn () => exit(1));
+                    }
+                }
+            }
+        );
+    }
+}

--- a/src/Enums/SpecSource.php
+++ b/src/Enums/SpecSource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spectator\Enums;
+
+enum SpecSource: string
+{
+    case Local = 'local';
+    case Remote = 'remote';
+    case Github = 'github';
+}

--- a/src/Enums/ValidationMode.php
+++ b/src/Enums/ValidationMode.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spectator\Enums;
+
+enum ValidationMode: string
+{
+    case Read = 'read';
+    case Write = 'write';
+}

--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -51,6 +51,12 @@ abstract class SchemaValidationException extends \Exception
      */
     public static function validationErrorMessage(stdClass $schema, ValidationError $validationError): string
     {
+        if (config('spectator.error_format', 'text') === 'json') {
+            return json_encode([
+                'errors' => self::formatValidationError($validationError, true),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        }
+
         // Capture the validation error as a map containing each (sub)error's location, keyword, and message.
         $errorFormatted = self::formatValidationError($validationError, false);
 
@@ -85,18 +91,18 @@ abstract class SchemaValidationException extends \Exception
 
         foreach ($schemaFormatted as $key => $schemaItem) {
             if (isset($errorLocationMap[$key])) {
-                $schemaItem = self::colorize($schemaItem, Format::TEXT_LIGHT_GREY);
-                $strings[] = $schemaItem.' <== '.self::colorize($errorLocationMap[$key]['error'], Format::TEXT_RED);
+                $schemaItem = self::colorize($schemaItem, Format::TextLightGrey);
+                $strings[] = $schemaItem.' <== '.self::colorize($errorLocationMap[$key]['error'], Format::TextRed);
             } elseif (isset($errorKeywordLocationMap[$key])) {
-                $schemaItem = self::colorize($schemaItem, Format::TEXT_LIGHT_GREY);
-                $strings[] = $schemaItem.' <== '.self::colorize($errorKeywordLocationMap[$key]['error'], Format::TEXT_RED);
+                $schemaItem = self::colorize($schemaItem, Format::TextLightGrey);
+                $strings[] = $schemaItem.' <== '.self::colorize($errorKeywordLocationMap[$key]['error'], Format::TextRed);
             } else {
-                $strings[] = self::colorize($schemaItem, Format::TEXT_GREEN);
+                $strings[] = self::colorize($schemaItem, Format::TextGreen);
             }
         }
 
         // Display the validation error alongside the expected schema with each (sub)error mapped over it.
-        $errorFlat = self::colorize(implode("\n", self::formatValidationError($validationError, true)), Format::TEXT_LIGHT_GREY, Format::STYLE_ITALIC);
+        $errorFlat = self::colorize(implode("\n", self::formatValidationError($validationError, true)), Format::TextLightGrey, Format::StyleItalic);
 
         return "---\n\n".$errorFlat."\n\n".implode("\n", $strings)."\n\n";
     }
@@ -301,8 +307,10 @@ abstract class SchemaValidationException extends \Exception
     /**
      * Colorize text.
      */
-    protected static function colorize(string $text, string $textColor, string $style = ''): string
+    protected static function colorize(string $text, Format $color, ?Format $style = null): string
     {
-        return "\e[{$textColor};{$style}m{$text}\e[0m";
+        $codes = array_filter([$color->value, $style?->value]);
+
+        return "\e[".implode(';', $codes)."m{$text}\e[0m";
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Str;
+use Spectator\Coverage\CoverageTracker;
 use Spectator\Exceptions\InvalidPathException;
 use Spectator\Exceptions\MalformedSpecException;
 use Spectator\Exceptions\MissingSpecException;
@@ -80,6 +81,11 @@ class Middleware
 
     protected function validate(Request $request, Closure $next, string $specPath, PathItem $pathItem): mixed
     {
+        $specName = $this->spectator->getSpec();
+        if ($specName !== null) {
+            CoverageTracker::record($specName, $request->method(), $specPath);
+        }
+
         try {
             RequestValidator::validate(
                 $request,
@@ -124,6 +130,19 @@ class Middleware
         $openapi = $this->spectator->resolve();
 
         $this->version = $openapi->openapi;
+
+        $specName = $this->spectator->getSpec();
+        if ($specName !== null) {
+            $ops = [];
+            foreach ($openapi->paths as $specItemPath => $specItem) {
+                foreach (['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as $method) {
+                    if ($specItem->{$method} !== null) {
+                        $ops[] = ['method' => strtoupper($method), 'path' => $specItemPath];
+                    }
+                }
+            }
+            CoverageTracker::recordSpec($specName, $ops);
+        }
 
         $pathMatches = false;
         $partialMatch = null;

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -11,6 +11,7 @@ use cebe\openapi\spec\OpenApi;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Spectator\Enums\SpecSource;
 use Spectator\Exceptions\MalformedSpecException;
 use Spectator\Exceptions\MissingSpecException;
 use Throwable;
@@ -64,6 +65,36 @@ class RequestFactory
     public function getPathPrefix(): string
     {
         return $this->pathPrefix ?? config('spectator.path_prefix') ?? '';
+    }
+
+    /**
+     * Fluent alias for setPathPrefix.
+     */
+    public function withPathPrefix(?string $pathPrefix): self
+    {
+        return $this->setPathPrefix($pathPrefix);
+    }
+
+    /**
+     * Configure validation errors to be emitted as machine-readable JSON.
+     *
+     * Useful for CI pipelines and LLM toolchains that parse test output.
+     */
+    public function useJsonErrors(): self
+    {
+        config()->set('spectator.error_format', 'json');
+
+        return $this;
+    }
+
+    /**
+     * Configure validation errors to be emitted as human-readable coloured text (default).
+     */
+    public function useTextErrors(): self
+    {
+        config()->set('spectator.error_format', 'text');
+
+        return $this;
     }
 
     /**
@@ -149,10 +180,10 @@ class RequestFactory
 
         $file = $this->standardizeFileName($this->specName);
 
-        return match ($source['source']) {
-            'local' => $this->getLocalPath($source, $file),
-            'remote' => $this->getRemotePath($source, $file),
-            'github' => $this->getGithubPath($source, $file),
+        return match (SpecSource::tryFrom($source['source'])) {
+            SpecSource::Local => $this->getLocalPath($source, $file),
+            SpecSource::Remote => $this->getRemotePath($source, $file),
+            SpecSource::Github => $this->getGithubPath($source, $file),
             default => throw new MissingSpecException('Cannot resolve schema with missing or invalid spec.'),
         };
     }
@@ -198,7 +229,9 @@ class RequestFactory
      */
     protected function getGithubPath(array $source, string $file): string
     {
-        return "https://{$source['token']}@raw.githubusercontent.com/{$source['repo']}/{$source['base_path']}/{$file}";
+        $basePath = trim($source['base_path'], '/');
+
+        return "https://{$source['token']}@raw.githubusercontent.com/{$source['repo']}/{$basePath}/{$file}";
     }
 
     /**

--- a/src/Spectator.php
+++ b/src/Spectator.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getSpec() Get the spec being used.
  * @method static string getPathPrefix() Get the path prefix being used.
  * @method static RequestFactory setPathPrefix(string|null $prefix) Set the path prefix being used.
+ * @method static RequestFactory withPathPrefix(string|null $prefix) Fluent alias for setPathPrefix.
+ * @method static RequestFactory useJsonErrors() Emit validation errors as machine-readable JSON.
+ * @method static RequestFactory useTextErrors() Emit validation errors as human-readable text (default).
  * @method static \stdClass resolve() Resolve the spec into an object.
  * @method bool shouldValidateRequest() Indicate if request should be validated.
  *

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\TestResponse;
+use Spectator\Console\CoverageCommand;
+use Spectator\Console\ValidateSpecCommand;
 
 class SpectatorServiceProvider extends ServiceProvider
 {
@@ -15,6 +17,10 @@ class SpectatorServiceProvider extends ServiceProvider
             $this->publishConfig();
             $this->registerMiddleware();
             $this->decorateTestResponse();
+            $this->commands([
+                ValidateSpecCommand::class,
+                CoverageCommand::class,
+            ]);
         }
     }
 

--- a/src/SpectatorServiceProvider.php
+++ b/src/SpectatorServiceProvider.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\TestResponse;
 use Spectator\Console\CoverageCommand;
+use Spectator\Console\RoutesCommand;
+use Spectator\Console\StubsCommand;
 use Spectator\Console\ValidateSpecCommand;
 
 class SpectatorServiceProvider extends ServiceProvider
@@ -20,6 +22,8 @@ class SpectatorServiceProvider extends ServiceProvider
             $this->commands([
                 ValidateSpecCommand::class,
                 CoverageCommand::class,
+                RoutesCommand::class,
+                StubsCommand::class,
             ]);
         }
     }

--- a/src/Support/Format.php
+++ b/src/Support/Format.php
@@ -2,19 +2,13 @@
 
 namespace Spectator\Support;
 
-class Format
+// https://joshtronic.com/2013/09/02/how-to-use-colors-in-command-line-output/
+enum Format: string
 {
-    // https://joshtronic.com/2013/09/02/how-to-use-colors-in-command-line-output/
-
-    const TEXT_GREEN = '0;32';
-
-    const TEXT_RED = '0;31';
-
-    const TEXT_WHITE = '1;37';
-
-    const TEXT_LIGHT_GREY = '0;37';
-
-    const TEXT_DARK_GREY = '1;30';
-
-    const STYLE_ITALIC = '3';
+    case TextGreen = '0;32';
+    case TextRed = '0;31';
+    case TextWhite = '1;37';
+    case TextLightGrey = '0;37';
+    case TextDarkGrey = '1;30';
+    case StyleItalic = '3';
 }

--- a/src/Validation/AbstractValidator.php
+++ b/src/Validation/AbstractValidator.php
@@ -59,6 +59,12 @@ abstract class AbstractValidator
             default => null
         };
 
+        // additionalProperties can coexist with properties/items/etc., so handle it separately.
+        // Only recurse when it's a Schema object (not a boolean true/false).
+        if (isset($data->additionalProperties) && is_object($data->additionalProperties)) {
+            $data->additionalProperties = $this->prepareProperty($data->additionalProperties, $mode);
+        }
+
         return $data;
     }
 

--- a/src/Validation/AbstractValidator.php
+++ b/src/Validation/AbstractValidator.php
@@ -5,6 +5,9 @@ namespace Spectator\Validation;
 use cebe\openapi\spec\Schema;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Opis\JsonSchema\Validator;
+use Spectator\Enums\ValidationMode;
+use Spectator\Exceptions\SchemaValidationException;
 use stdClass;
 
 abstract class AbstractValidator
@@ -13,15 +16,13 @@ abstract class AbstractValidator
 
     /**
      * Check if properties exist, and if so, prepare them based on version.
-     *
-     * @param  'read'|'write'|null  $mode
      */
-    protected function prepareData(Schema $schema, ?string $mode = null): stdClass
+    protected function prepareData(Schema $schema, ?ValidationMode $mode = null): stdClass
     {
         return $this->prepareProperty($schema->getSerializableData(), $mode);
     }
 
-    private function prepareProperty(stdClass $data, ?string $mode): stdClass
+    private function prepareProperty(stdClass $data, ?ValidationMode $mode): stdClass
     {
         // Does this object contain an unresolved "$ref"? This occurs when `cebe\openapi\Reader`
         // encounters a cyclical reference. Skip it.
@@ -80,14 +81,12 @@ abstract class AbstractValidator
 
     /**
      * Filters out readonly|writeonly properties.
-     *
-     * @param  string|null  $mode  Access mode 'read' or 'write'
      */
-    private function filterProperties(stdClass $data, ?string $mode): stdClass
+    private function filterProperties(stdClass $data, ?ValidationMode $mode): stdClass
     {
         $filterBy = match ($mode) {
-            'read' => 'writeOnly',
-            'write' => 'readOnly',
+            ValidationMode::Read => 'writeOnly',
+            ValidationMode::Write => 'readOnly',
             default => null,
         };
 
@@ -145,5 +144,23 @@ abstract class AbstractValidator
         }
 
         return $data;
+    }
+
+    /**
+     * Run schema validation, throwing the given exception class on failure.
+     *
+     * @param  class-string<SchemaValidationException>  $exceptionClass
+     *
+     * @throws SchemaValidationException
+     */
+    protected function runValidation(mixed $data, stdClass $schema, string $exceptionClass): void
+    {
+        $result = (new Validator)->validate($data, $schema);
+
+        if (! $result->isValid()) {
+            $message = $exceptionClass::validationErrorMessage($schema, $result->error());
+
+            throw $exceptionClass::withError($message, $result->error());
+        }
     }
 }

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Opis\JsonSchema\Validator;
+use Spectator\Enums\ValidationMode;
 use Spectator\Exceptions\RequestValidationException;
 use Spectator\Exceptions\SchemaValidationException;
 use stdClass;
@@ -175,18 +176,9 @@ class RequestValidator extends AbstractValidator
             throw new RequestValidationException('Request body required!');
         }
 
-        $expectedBodySchema = $this->prepareData($expectedBodyRawSchema, 'write');
+        $expectedBodySchema = $this->prepareData($expectedBodyRawSchema, ValidationMode::Write);
 
-        // Run validation.
-        $validator = new Validator;
-        $result = $validator->validate($actualBodySchema, $expectedBodySchema);
-
-        // If the result is not valid, then display failure reason.
-        if ($result->isValid() === false) {
-            $message = RequestValidationException::validationErrorMessage($expectedBodySchema, $result->error());
-
-            throw RequestValidationException::withError($message, $result->error());
-        }
+        $this->runValidation($actualBodySchema, $expectedBodySchema, RequestValidationException::class);
     }
 
     protected function operation(): Operation
@@ -244,9 +236,9 @@ class RequestValidator extends AbstractValidator
         if (! is_array($data)) {
             return $data;
         } elseif (Arr::isAssoc($data)) {
-            return (object) array_map([$this, 'toObject'], $data);
+            return (object) array_map($this->toObject(...), $data);
         } else {
-            return array_map([$this, 'toObject'], $data);
+            return array_map($this->toObject(...), $data);
         }
     }
 

--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -104,6 +104,10 @@ class RequestValidator extends AbstractValidator
                     }
                 } elseif ($parameter->in === 'header' && $this->request->headers->has($parameter->name)) {
                     $parameterValue = $this->request->headers->get($parameter->name);
+
+                    if ($parameter->explode === false && $parameter->schema->type === 'array') {
+                        $parameterValue = explode(',', $parameterValue);
+                    }
                 } elseif ($parameter->in === 'cookie' && $this->request->cookies->has($parameter->name)) {
                     $parameterValue = $this->request->cookies->get($parameter->name);
                 }

--- a/src/Validation/ResponseValidator.php
+++ b/src/Validation/ResponseValidator.php
@@ -7,7 +7,7 @@ use cebe\openapi\spec\Response;
 use cebe\openapi\spec\Schema;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Opis\JsonSchema\Validator;
+use Spectator\Enums\ValidationMode;
 use Spectator\Exceptions\ResponseValidationException;
 use Spectator\Exceptions\SchemaValidationException;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
@@ -79,16 +79,9 @@ class ResponseValidator extends AbstractValidator
      */
     protected function validateResponse(Schema $schema, mixed $body): void
     {
-        $expectedSchema = $this->prepareData($schema, 'read');
+        $expectedSchema = $this->prepareData($schema, ValidationMode::Read);
 
-        $validator = new Validator;
-        $result = $validator->validate($body, $expectedSchema);
-
-        if ($result->isValid() === false) {
-            $message = ResponseValidationException::validationErrorMessage($expectedSchema, $result->error());
-
-            throw ResponseValidationException::withError($message, $result->error());
-        }
+        $this->runValidation($body, $expectedSchema, ResponseValidationException::class);
     }
 
     /**

--- a/tests/Console/CoverageCommandTest.php
+++ b/tests/Console/CoverageCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spectator\Tests\Console;
+
+use Spectator\Tests\TestCase;
+
+class CoverageCommandTest extends TestCase
+{
+    public function test_lists_operations_text_format(): void
+    {
+        $this->artisan('spectator:coverage', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('Operations in Test.v1.yml')
+            ->expectsOutputToContain('GET')
+            ->expectsOutputToContain('/users');
+    }
+
+    public function test_lists_operations_json_format(): void
+    {
+        $this->artisan('spectator:coverage', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"spec": "Test.v1.yml"')
+            ->expectsOutputToContain('"operations"');
+    }
+
+    public function test_json_output_contains_operations(): void
+    {
+        $this->artisan('spectator:coverage', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"method": "GET"')
+            ->expectsOutputToContain('"path": "/users"');
+    }
+
+    public function test_fails_when_no_spec_specified(): void
+    {
+        $this->artisan('spectator:coverage')
+            ->assertExitCode(1)
+            ->expectsOutputToContain('No spec file specified');
+    }
+
+    public function test_fails_for_nonexistent_spec(): void
+    {
+        $this->artisan('spectator:coverage', ['--spec' => 'DoesNotExist.v1.yml'])
+            ->assertExitCode(1);
+    }
+
+    public function test_text_format_shows_operation_count(): void
+    {
+        $this->artisan('spectator:coverage', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('operation(s) found');
+    }
+}

--- a/tests/Console/RoutesCommandTest.php
+++ b/tests/Console/RoutesCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Spectator\Tests\Console;
+
+use Illuminate\Support\Facades\Route;
+use Spectator\Tests\TestCase;
+
+class RoutesCommandTest extends TestCase
+{
+    public function test_shows_matched_routes(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+        Route::post('/users', fn () => [])->name('users.store');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('matched');
+    }
+
+    public function test_shows_unimplemented_when_route_missing(): void
+    {
+        // Deliberately register NO routes — all spec operations are unimplemented
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('unimplemented');
+    }
+
+    public function test_shows_undocumented_when_route_not_in_spec(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+        Route::get('/not-in-spec', fn () => [])->name('extra');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('undocumented');
+    }
+
+    public function test_json_format_contains_spec_operations(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"spec_operations"')
+            ->expectsOutputToContain('"spec": "Test.v1.yml"');
+    }
+
+    public function test_json_format_contains_undocumented(): void
+    {
+        Route::get('/not-in-spec', fn () => [])->name('extra');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"undocumented_routes"');
+    }
+
+    public function test_json_format_matched_status(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+        Route::post('/users', fn () => [])->name('users.store');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"status": "matched"');
+    }
+
+    public function test_json_format_unimplemented_status(): void
+    {
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"status": "unimplemented"');
+    }
+
+    public function test_fails_when_no_spec_specified(): void
+    {
+        $this->artisan('spectator:routes')
+            ->assertExitCode(1)
+            ->expectsOutputToContain('No spec file specified');
+    }
+
+    public function test_fails_for_nonexistent_spec(): void
+    {
+        $this->artisan('spectator:routes', ['--spec' => 'DoesNotExist.v1.yml'])
+            ->assertExitCode(1);
+    }
+
+    public function test_summary_line_shown(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('matched,');
+    }
+}

--- a/tests/Console/StubsCommandTest.php
+++ b/tests/Console/StubsCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Spectator\Tests\Console;
+
+use Illuminate\Support\Facades\File;
+use Spectator\Tests\TestCase;
+
+class StubsCommandTest extends TestCase
+{
+    private string $outputDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->outputDir = sys_get_temp_dir().'/spectator-stubs-test-'.uniqid();
+        File::ensureDirectoryExists($this->outputDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->outputDir);
+        parent::tearDown();
+    }
+
+    public function test_generates_stub_files(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0);
+
+        $this->assertNotEmpty(File::files($this->outputDir));
+    }
+
+    public function test_generated_class_contains_namespace(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+            '--namespace' => 'App\\Tests\\Contract',
+        ])->assertExitCode(0);
+
+        $contents = $this->getFirstFileContents();
+        $this->assertStringContainsString('namespace App\\Tests\\Contract;', $contents);
+    }
+
+    public function test_generated_class_extends_base_class(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+            '--base-class' => 'PHPUnit\\Framework\\TestCase',
+        ])->assertExitCode(0);
+
+        $contents = $this->getFirstFileContents();
+        $this->assertStringContainsString('extends TestCase', $contents);
+        $this->assertStringContainsString('use PHPUnit\\Framework\\TestCase;', $contents);
+    }
+
+    public function test_generated_methods_use_mark_test_incomplete(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0);
+
+        $contents = $this->getFirstFileContents();
+        $this->assertStringContainsString('markTestIncomplete', $contents);
+    }
+
+    public function test_generated_setup_calls_spectator_using(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0);
+
+        $contents = $this->getFirstFileContents();
+        $this->assertStringContainsString("Spectator::using('Test.v1.yml')", $contents);
+    }
+
+    public function test_uses_operation_id_as_method_name(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0);
+
+        $contents = $this->getFirstFileContents();
+        // Test.v1.yml has operationId "get-users" → test_get_users
+        $this->assertStringContainsString('test_get_users', $contents);
+    }
+
+    public function test_skips_existing_files_without_force(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0);
+
+        $before = $this->getFirstFileContents();
+
+        // Overwrite first-run file with sentinel content
+        $firstFile = File::files($this->outputDir)[0];
+        File::put($firstFile->getPathname(), '<?php // sentinel');
+
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0)
+            ->expectsOutputToContain('SKIP');
+
+        $this->assertStringContainsString('sentinel', File::get($firstFile->getPathname()));
+    }
+
+    public function test_force_overwrites_existing_files(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0);
+
+        $firstFile = File::files($this->outputDir)[0];
+        File::put($firstFile->getPathname(), '<?php // sentinel');
+
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $this->assertStringNotContainsString('sentinel', File::get($firstFile->getPathname()));
+    }
+
+    public function test_fails_when_no_spec_specified(): void
+    {
+        $this->artisan('spectator:stubs')
+            ->assertExitCode(1)
+            ->expectsOutputToContain('No spec file specified');
+    }
+
+    public function test_fails_for_nonexistent_spec(): void
+    {
+        $this->artisan('spectator:stubs', ['--spec' => 'DoesNotExist.v1.yml'])
+            ->assertExitCode(1);
+    }
+
+    public function test_reports_files_written(): void
+    {
+        $this->artisan('spectator:stubs', [
+            '--spec' => 'Test.v1.yml',
+            '--output' => $this->outputDir,
+        ])->assertExitCode(0)
+            ->expectsOutputToContain('file(s) written');
+    }
+
+    private function getFirstFileContents(): string
+    {
+        $files = File::files($this->outputDir);
+        $this->assertNotEmpty($files, 'No stub files were generated.');
+
+        return File::get($files[0]->getPathname());
+    }
+}

--- a/tests/Console/ValidateSpecCommandTest.php
+++ b/tests/Console/ValidateSpecCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Spectator\Tests\Console;
+
+use Spectator\Tests\TestCase;
+
+class ValidateSpecCommandTest extends TestCase
+{
+    public function test_validates_valid_spec_text_format(): void
+    {
+        $this->artisan('spectator:validate', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('is valid');
+    }
+
+    public function test_validates_valid_spec_json_format(): void
+    {
+        $this->artisan('spectator:validate', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"valid": true');
+
+        $this->artisan('spectator:validate', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"spec": "Test.v1.yml"');
+    }
+
+    public function test_fails_when_no_spec_specified(): void
+    {
+        $this->artisan('spectator:validate')
+            ->assertExitCode(1)
+            ->expectsOutputToContain('No spec file specified');
+    }
+
+    public function test_fails_when_no_spec_specified_json_format(): void
+    {
+        $this->artisan('spectator:validate', ['--format' => 'json'])
+            ->assertExitCode(1);
+
+        // JSON output should indicate failure
+        $this->artisan('spectator:validate', ['--format' => 'json'])
+            ->assertExitCode(1)
+            ->expectsOutputToContain('"valid": false');
+    }
+
+    public function test_fails_for_nonexistent_spec(): void
+    {
+        $this->artisan('spectator:validate', ['--spec' => 'DoesNotExist.v1.yml'])
+            ->assertExitCode(1)
+            ->expectsOutputToContain('DoesNotExist.v1.yml');
+    }
+
+    public function test_fails_for_nonexistent_spec_json_format(): void
+    {
+        $this->artisan('spectator:validate', ['--spec' => 'DoesNotExist.v1.yml', '--format' => 'json'])
+            ->assertExitCode(1)
+            ->expectsOutputToContain('"valid": false');
+    }
+
+    public function test_validates_json_spec(): void
+    {
+        $this->artisan('spectator:validate', ['--spec' => 'Test.v1.json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('is valid');
+    }
+}

--- a/tests/Coverage/CoverageIntegrationTest.php
+++ b/tests/Coverage/CoverageIntegrationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Spectator\Tests\Coverage;
+
+use Illuminate\Support\Facades\Route;
+use Spectator\Coverage\CoverageTracker;
+use Spectator\Middleware;
+use Spectator\Spectator;
+use Spectator\Tests\TestCase;
+
+class CoverageIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CoverageTracker::reset();
+    }
+
+    public function test_middleware_records_spec_on_first_request(): void
+    {
+        Spectator::using('Test.v1.yml');
+
+        Route::get('/users', fn () => response()->json([
+            ['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com'],
+        ]))->middleware(Middleware::class);
+
+        $this->getJson('/users');
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertArrayHasKey('Test.v1.yml', $data);
+        $this->assertGreaterThan(0, $data['Test.v1.yml']['total']);
+    }
+
+    public function test_middleware_records_covered_operation(): void
+    {
+        Spectator::using('Test.v1.yml');
+
+        Route::get('/users', fn () => response()->json([
+            ['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com'],
+        ]))->middleware(Middleware::class);
+
+        $this->getJson('/users');
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertGreaterThan(0, $data['Test.v1.yml']['covered']);
+
+        $coveredKeys = array_column(
+            array_filter($data['Test.v1.yml']['operations'], fn ($op) => $op['covered']),
+            'key'
+        );
+        $this->assertContains('GET /users', $coveredKeys);
+    }
+
+    public function test_middleware_records_spec_operations_only_once(): void
+    {
+        Spectator::using('Test.v1.yml');
+
+        Route::get('/users', fn () => response()->json([
+            ['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com'],
+        ]))->middleware(Middleware::class);
+
+        $this->getJson('/users');
+        $afterFirst = CoverageTracker::getBySpec()['Test.v1.yml']['total'];
+
+        // A second request must NOT change the total operation count
+        $this->getJson('/users');
+        $afterSecond = CoverageTracker::getBySpec()['Test.v1.yml']['total'];
+
+        $this->assertSame($afterFirst, $afterSecond);
+    }
+
+    public function test_noop_when_no_spec_set(): void
+    {
+        Spectator::using(null);
+
+        Route::get('/users', fn () => response()->noContent())->middleware(Middleware::class);
+
+        $this->getJson('/users');
+
+        $this->assertEmpty(CoverageTracker::getBySpec());
+    }
+}

--- a/tests/Coverage/CoverageTrackerTest.php
+++ b/tests/Coverage/CoverageTrackerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Spectator\Tests\Coverage;
+
+use PHPUnit\Framework\TestCase;
+use Spectator\Coverage\CoverageTracker;
+
+class CoverageTrackerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        CoverageTracker::reset();
+    }
+
+    public function test_records_spec_operations(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+            ['method' => 'POST', 'path' => '/users'],
+        ]);
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertArrayHasKey('Api.v1.yml', $data);
+        $this->assertSame(2, $data['Api.v1.yml']['total']);
+        $this->assertSame(0, $data['Api.v1.yml']['covered']);
+    }
+
+    public function test_records_covered_operation(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+            ['method' => 'POST', 'path' => '/users'],
+        ]);
+
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertSame(1, $data['Api.v1.yml']['covered']);
+        $this->assertSame(50.0, $data['Api.v1.yml']['percent']);
+    }
+
+    public function test_spec_recorded_only_once(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+        ]);
+
+        // Second call with more operations must be ignored (idempotent guard)
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+            ['method' => 'POST', 'path' => '/users'],
+        ]);
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertSame(1, $data['Api.v1.yml']['total']);
+    }
+
+    public function test_covered_ops_use_set_semantics(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+        ]);
+
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertSame(1, $data['Api.v1.yml']['covered']);
+    }
+
+    public function test_normalizes_method_to_uppercase(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'get', 'path' => '/users'],
+        ]);
+
+        CoverageTracker::record('Api.v1.yml', 'get', '/users');
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertSame(1, $data['Api.v1.yml']['covered']);
+    }
+
+    public function test_reset_clears_all_data(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [['method' => 'GET', 'path' => '/users']]);
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+
+        CoverageTracker::reset();
+
+        $this->assertEmpty(CoverageTracker::getBySpec());
+    }
+
+    public function test_tracks_multiple_specs_independently(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [['method' => 'GET', 'path' => '/users']]);
+        CoverageTracker::recordSpec('Admin.v1.yml', [['method' => 'GET', 'path' => '/admin']]);
+
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertSame(100.0, $data['Api.v1.yml']['percent']);
+        $this->assertSame(0.0, $data['Admin.v1.yml']['percent']);
+    }
+
+    public function test_percent_is_zero_for_empty_spec(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', []);
+
+        $data = CoverageTracker::getBySpec();
+        $this->assertSame(0.0, $data['Api.v1.yml']['percent']);
+    }
+
+    public function test_operations_contain_covered_flag(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+            ['method' => 'POST', 'path' => '/users'],
+        ]);
+
+        CoverageTracker::record('Api.v1.yml', 'GET', '/users');
+
+        $data = CoverageTracker::getBySpec();
+        $ops = $data['Api.v1.yml']['operations'];
+
+        $this->assertCount(2, $ops);
+        $getOp = array_values(array_filter($ops, fn ($op) => $op['key'] === 'GET /users'))[0];
+        $postOp = array_values(array_filter($ops, fn ($op) => $op['key'] === 'POST /users'))[0];
+
+        $this->assertTrue($getOp['covered']);
+        $this->assertFalse($postOp['covered']);
+    }
+
+    public function test_uncovered_ops_not_counted(): void
+    {
+        CoverageTracker::recordSpec('Api.v1.yml', [
+            ['method' => 'GET', 'path' => '/users'],
+            ['method' => 'PUT', 'path' => '/users/{id}'],
+        ]);
+
+        // Record an operation not in the spec — must not inflate covered count
+        CoverageTracker::record('Api.v1.yml', 'DELETE', '/users/{id}');
+
+        $data = CoverageTracker::getBySpec();
+        // covered is intersection of spec ops and recorded ops
+        $this->assertSame(0, $data['Api.v1.yml']['covered']);
+    }
+}

--- a/tests/Fixtures/CommaSeparatedString.v1.json
+++ b/tests/Fixtures/CommaSeparatedString.v1.json
@@ -115,6 +115,18 @@
                 "enum": ["foo", "bar"]
               }
             }
+          },
+          {
+            "name": "X-Include",
+            "in": "header",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["foo", "bar"]
+              }
+            }
           }
         ]
       }

--- a/tests/Fixtures/Dictionary.v1.yml
+++ b/tests/Fixtures/Dictionary.v1.yml
@@ -38,5 +38,22 @@ paths:
                     nullable: true
                     additionalProperties:
                       type: integer
+  /nullable-value-dictionary:
+    get:
+      summary: Get dictionary with nullable string values
+      tags: [ ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties:
+                      type: string
+                      nullable: true
 components:
   schemas: {}

--- a/tests/JsonErrorFormatTest.php
+++ b/tests/JsonErrorFormatTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Spectator\Tests;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Spectator\Middleware;
+use Spectator\Spectator;
+
+class JsonErrorFormatTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Spectator::using('Test.v1.yml');
+    }
+
+    #[Test]
+    public function default_error_format_is_text(): void
+    {
+        $this->assertEquals('text', config('spectator.error_format', 'text'));
+    }
+
+    #[Test]
+    public function use_json_errors_sets_json_format(): void
+    {
+        Spectator::useJsonErrors();
+
+        $this->assertEquals('json', config('spectator.error_format'));
+    }
+
+    #[Test]
+    public function use_text_errors_sets_text_format(): void
+    {
+        Spectator::useJsonErrors();
+        Spectator::useTextErrors();
+
+        $this->assertEquals('text', config('spectator.error_format'));
+    }
+
+    #[Test]
+    public function request_validation_error_emits_json_when_configured(): void
+    {
+        Spectator::useJsonErrors();
+
+        Route::post('/users', fn () => response()->json([], 201))->middleware(Middleware::class);
+
+        // Send request missing required fields — triggers RequestValidationException
+        $this->postJson('/users', [])
+            ->assertInvalidRequest();
+
+        $message = app('spectator')->requestException->getMessage();
+
+        $decoded = json_decode($message, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('errors', $decoded);
+        $this->assertNotEmpty($decoded['errors']);
+    }
+
+    #[Test]
+    public function response_validation_error_emits_json_when_configured(): void
+    {
+        Spectator::useJsonErrors();
+
+        Route::get('/users', fn () => response()->json(['id' => 'not-an-integer']))->middleware(Middleware::class);
+
+        $this->getJson('/users')
+            ->assertInvalidResponse();
+
+        $message = app('spectator')->responseException->getMessage();
+
+        $decoded = json_decode($message, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('errors', $decoded);
+        $this->assertNotEmpty($decoded['errors']);
+    }
+
+    #[Test]
+    public function request_validation_error_emits_text_by_default(): void
+    {
+        Route::post('/users', fn () => response()->json([], 201))->middleware(Middleware::class);
+
+        $this->postJson('/users', [])
+            ->assertInvalidRequest();
+
+        $message = app('spectator')->requestException->getMessage();
+
+        // Text format contains ANSI escape codes or schema-style markers, not JSON
+        $this->assertNull(json_decode($message));
+    }
+
+    #[Test]
+    public function json_errors_can_be_configured_via_env(): void
+    {
+        Config::set('spectator.error_format', 'json');
+
+        Route::post('/users', fn () => response()->json([], 201))->middleware(Middleware::class);
+
+        $this->postJson('/users', [])
+            ->assertInvalidRequest();
+
+        $message = app('spectator')->requestException->getMessage();
+
+        $decoded = json_decode($message, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('errors', $decoded);
+    }
+}

--- a/tests/RequestFactoryTest.php
+++ b/tests/RequestFactoryTest.php
@@ -4,7 +4,9 @@ namespace Spectator\Tests;
 
 use cebe\openapi\spec\OpenApi;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
 use Spectator\Exceptions\MissingSpecException;
 use Spectator\RequestFactory;
 
@@ -212,5 +214,193 @@ class RequestFactoryTest extends TestCase
         Config::set('spectator.path_prefix', null);
 
         $this->assertSame('', $factory->getPathPrefix());
+    }
+
+    // -------------------------------------------------------------------------
+    // Remote source
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function resolves_json_spec_from_remote_source(): void
+    {
+        $fixturesPath = realpath(__DIR__.'/Fixtures');
+
+        Config::set('spectator.default', 'remote');
+        Config::set('spectator.sources.remote', [
+            'source' => 'remote',
+            'base_path' => $fixturesPath,
+            'params' => '',
+        ]);
+
+        $factory = new RequestFactory;
+        $factory->using('Test.v1.json');
+
+        $spec = $factory->resolve();
+
+        $this->assertInstanceOf(OpenApi::class, $spec);
+        $this->assertSame('Test.v1', $spec->info->title);
+    }
+
+    #[Test]
+    public function resolves_yaml_spec_from_remote_source(): void
+    {
+        $fixturesPath = realpath(__DIR__.'/Fixtures');
+
+        Config::set('spectator.default', 'remote');
+        Config::set('spectator.sources.remote', [
+            'source' => 'remote',
+            'base_path' => $fixturesPath,
+            'params' => '',
+        ]);
+
+        $factory = new RequestFactory;
+        $factory->using('Test.v1.yml');
+
+        $spec = $factory->resolve();
+
+        $this->assertInstanceOf(OpenApi::class, $spec);
+        $this->assertSame('Test.v1', $spec->info->title);
+    }
+
+    #[Test]
+    public function remote_source_constructs_url_with_params(): void
+    {
+        $factory = new RequestFactory;
+
+        $method = new ReflectionMethod($factory, 'getRemotePath');
+
+        $url = $method->invoke($factory, [
+            'source' => 'remote',
+            'base_path' => 'https://example.com/specs',
+            'params' => '?token=abc123',
+        ], 'Api.v1.yml');
+
+        $this->assertSame('https://example.com/specs/Api.v1.yml?token=abc123', $url);
+    }
+
+    #[Test]
+    public function remote_source_constructs_url_without_params(): void
+    {
+        $factory = new RequestFactory;
+
+        $method = new ReflectionMethod($factory, 'getRemotePath');
+
+        $url = $method->invoke($factory, [
+            'source' => 'remote',
+            'base_path' => 'https://example.com/specs',
+            'params' => '',
+        ], 'Api.v1.yml');
+
+        $this->assertSame('https://example.com/specs/Api.v1.yml', $url);
+    }
+
+    #[Test]
+    public function remote_source_adds_trailing_slash_to_base_path(): void
+    {
+        $factory = new RequestFactory;
+
+        $method = new ReflectionMethod($factory, 'getRemotePath');
+
+        $urlWithSlash = $method->invoke($factory, ['source' => 'remote', 'base_path' => 'https://example.com/specs/', 'params' => ''], 'Api.v1.yml');
+        $urlWithoutSlash = $method->invoke($factory, ['source' => 'remote', 'base_path' => 'https://example.com/specs', 'params' => ''], 'Api.v1.yml');
+
+        $this->assertSame($urlWithSlash, $urlWithoutSlash);
+    }
+
+    // -------------------------------------------------------------------------
+    // GitHub source
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function github_source_constructs_correct_url(): void
+    {
+        $factory = new RequestFactory;
+
+        $method = new ReflectionMethod($factory, 'getGithubPath');
+
+        $url = $method->invoke($factory, [
+            'source' => 'github',
+            'token' => 'ghp_mytoken',
+            'repo' => 'org/my-repo',
+            'base_path' => 'main/specs',
+        ], 'Api.v1.yml');
+
+        $this->assertSame('https://ghp_mytoken@raw.githubusercontent.com/org/my-repo/main/specs/Api.v1.yml', $url);
+    }
+
+    #[Test]
+    public function github_source_trims_trailing_slash_from_base_path(): void
+    {
+        $factory = new RequestFactory;
+
+        $method = new ReflectionMethod($factory, 'getGithubPath');
+
+        $urlWithSlash = $method->invoke($factory, [
+            'source' => 'github',
+            'token' => 'ghp_mytoken',
+            'repo' => 'org/my-repo',
+            'base_path' => 'main/specs/',
+        ], 'Api.v1.yml');
+
+        $urlWithoutSlash = $method->invoke($factory, [
+            'source' => 'github',
+            'token' => 'ghp_mytoken',
+            'repo' => 'org/my-repo',
+            'base_path' => 'main/specs',
+        ], 'Api.v1.yml');
+
+        $this->assertSame($urlWithoutSlash, $urlWithSlash);
+        $this->assertStringNotContainsString('//', str_replace('https://', '', $urlWithSlash));
+    }
+
+    #[Test]
+    public function github_source_trims_leading_slash_from_base_path(): void
+    {
+        $factory = new RequestFactory;
+
+        $method = new ReflectionMethod($factory, 'getGithubPath');
+
+        $url = $method->invoke($factory, [
+            'source' => 'github',
+            'token' => 'ghp_mytoken',
+            'repo' => 'org/my-repo',
+            'base_path' => '/main/specs',
+        ], 'Api.v1.yml');
+
+        $this->assertSame('https://ghp_mytoken@raw.githubusercontent.com/org/my-repo/main/specs/Api.v1.yml', $url);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function specFileProvider(): array
+    {
+        return [
+            'json file' => ['Test.v1.json', 'Test.v1'],
+            'yml file' => ['Test.v1.yml', 'Test.v1'],
+            'yaml file' => ['Test.v1.yaml', 'Test.v1'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('specFileProvider')]
+    public function resolves_spec_from_remote_source_for_different_formats(string $specFile, string $expectedTitle): void
+    {
+        $fixturesPath = realpath(__DIR__.'/Fixtures');
+
+        Config::set('spectator.default', 'remote');
+        Config::set('spectator.sources.remote', [
+            'source' => 'remote',
+            'base_path' => $fixturesPath,
+            'params' => '',
+        ]);
+
+        $factory = new RequestFactory;
+        $factory->using($specFile);
+
+        $spec = $factory->resolve();
+
+        $this->assertInstanceOf(OpenApi::class, $spec);
+        $this->assertSame($expectedTitle, $spec->info->title);
     }
 }

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -803,7 +803,9 @@ class RequestValidatorTest extends TestCase
         })
             ->middleware(Middleware::class);
 
-        $this->getJson('/users?include=foo,bar')
+        $this
+            ->withHeader('X-Include', 'foo,bar')
+            ->getJson('/users?include=foo,bar')
             ->assertStatus(200)
             ->assertValidRequest()
             ->assertValidResponse();

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -1283,4 +1283,45 @@ class ResponseValidatorTest extends TestCase
             ],
         ];
     }
+
+    #[DataProvider('nullableValueDictionaryProvider')]
+    #[Test]
+    public function nullable_value_dictionary(mixed $payload, bool $isValid): void
+    {
+        Spectator::using('Dictionary.v1.yml');
+
+        Route::get('/nullable-value-dictionary', static function () use ($payload) {
+            return ['data' => $payload];
+        })->middleware(Middleware::class);
+
+        if ($isValid) {
+            $this->getJson('/nullable-value-dictionary')
+                ->assertValidResponse();
+        } else {
+            $this->getJson('/nullable-value-dictionary')
+                ->assertInvalidResponse();
+        }
+    }
+
+    public static function nullableValueDictionaryProvider(): array
+    {
+        return [
+            'valid as string values' => [
+                ['foo' => 'hello', 'bar' => 'world'],
+                true,
+            ],
+            'valid as null values' => [
+                ['foo' => null, 'bar' => null],
+                true,
+            ],
+            'valid mixed null and string' => [
+                ['foo' => 'hello', 'bar' => null],
+                true,
+            ],
+            'invalid as integer values' => [
+                ['foo' => 1, 'bar' => 2],
+                false,
+            ],
+        ];
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spectator\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spectator\RequestFactory;
 
 abstract class TestCase extends Orchestra
 {
@@ -26,5 +27,7 @@ abstract class TestCase extends Orchestra
         parent::setUp();
 
         $this->withoutExceptionHandling();
+
+        RequestFactory::clearCache();
     }
 }


### PR DESCRIPTION
## Spectator v3

This PR is a major version bump that modernises Spectator for the current PHP and Laravel ecosystem, adds new developer tooling, and lays groundwork for AI-assisted API workflows.

---

### Breaking Changes

- **PHP 8.3+** and **Laravel 12+** are now the minimum requirements.
- Internal string/class constants replaced with proper PHP enums (`SpecSource`, `ValidationMode`, `Format`). If you extend Spectator's validators or reference these constants directly, see [UPGRADE.md](UPGRADE.md).
- New `error_format` config key (`text` by default). See Configuration below.

Full upgrade notes: [UPGRADE.md](UPGRADE.md).

---

### New Features

#### Artisan Commands

**`spectator:validate`** — lint a spec file before running tests.

```bash
php artisan spectator:validate --spec=Api.v1.yml
php artisan spectator:validate --spec=Api.v1.yml --format=json
```

**`spectator:coverage`** — list every operation defined in a spec (useful for gap analysis).

```bash
php artisan spectator:coverage --spec=Api.v1.yml
php artisan spectator:coverage --spec=Api.v1.yml --format=json
```

**`spectator:routes`** — cross-reference spec operations against registered Laravel routes. Surfaces matched, unimplemented, and undocumented endpoints.

```bash
php artisan spectator:routes --spec=Api.v1.yml
php artisan spectator:routes --spec=Api.v1.yml --format=json
```

```
 ──────── ──────── ─────────────────── 
  Status   Method   Path
 ──────── ──────── ─────────────────── 
  ✔        GET      /users
  ✔        POST     /users
  ✗        DELETE   /users/{id}
  ⚠        GET      /internal
 ──────── ──────── ─────────────────── 
Matched: 2  |  Unimplemented: 1  |  Undocumented: 1
```

**`spectator:stubs`** — generate skeleton test classes from a spec. Groups operations by tag (fallback: first path segment), creates one class per group with one `test_` method per operation calling `markTestIncomplete(...)`.

```bash
php artisan spectator:stubs --spec=Api.v1.yml
php artisan spectator:stubs --spec=Api.v1.yml --output=tests/Contract --namespace="Tests\\Contract"
php artisan spectator:stubs --spec=Api.v1.yml --force
```

All commands return exit code `0` on success and `1` on failure, making them CI-friendly. All support `--format=json` for machine-readable output.

#### PHPUnit Coverage Extension

`SpectatorExtension` is a PHPUnit 11 extension that tracks which spec operations are exercised during a test run and prints a coverage summary when the suite finishes. Opt in via `phpunit.xml`:

```xml
<extensions>
    <bootstrap class="Spectator\Coverage\SpectatorExtension">
        <parameter name="min_coverage" value="80"/>
        <parameter name="format" value="text"/>
    </bootstrap>
</extensions>
```

When `min_coverage` is set and not met, the extension causes PHPUnit to exit with code `1`, failing the CI job.

#### Machine-Readable JSON Errors

For CI pipelines and LLM toolchains that parse test output programmatically:

```env
SPECTATOR_ERROR_FORMAT=json
```

Failed assertions emit structured JSON instead of ANSI-coloured text:

```json
{"errors": ["The data (null) must match the type: string"]}
```

Toggle per-test with `Spectator::useJsonErrors()` / `Spectator::useTextErrors()`.

#### Fluent Path-Prefix API

```php
Spectator::withPathPrefix('v1');  // alias for setPathPrefix()
```

---

### Internals

- Enums replace string/class constants throughout (`SpecSource`, `ValidationMode`, `Format`).
- First-class callables, `match` expressions, and typed properties adopted where appropriate.
- `runValidation()` extracted to `AbstractValidator` to remove duplication between `RequestValidator` and `ResponseValidator`.
- Remote and GitHub spec source fetching verified and fixed.

---

### Workflow Changes

- CI matrix covers **PHP 8.3 + 8.4** against **Laravel 12 + 13** (aligned with new minimums, open upper bound for future versions).
- PHPStan workflow now also runs on `pull_request` (previously push-only).
- Removed deprecated `--no-suggest` Composer flag.

---

### Tests

244 tests, 244 passing. 0 PHPStan errors.