### PR TITLE
Add --prefix and --middleware filters to spectator:routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,21 @@ Matched: 2  |  Unimplemented: 1  |  Undocumented: 1
 - `✗ unimplemented` — in spec, no matching Laravel route
 - `⚠ undocumented` — Laravel route exists, not in spec
 
+#### Scoping the comparison
+
+If your spec only documents a subset of the app's routes (e.g. the public `/api/v2/*` surface), every internal admin/web/webhook route otherwise shows up as `undocumented` and drowns the signal. Two flags narrow the Laravel side of the comparison:
+
+- `--prefix=api/v2` — only consider routes whose URI starts with the given prefix. Leading/trailing slashes are normalised.
+- `--middleware=api` — only consider routes that have the given middleware. Both group aliases (`api`, `web`) and fully-qualified class names work.
+
+Both can be combined (AND) and only affect the Laravel-routes side — spec operations are still listed as you wrote them. If neither is set, behavior is unchanged.
+
+```bash
+php artisan spectator:routes --spec=Api.v1.yml --prefix=api/v2
+php artisan spectator:routes --spec=Api.v1.yml --middleware=api
+php artisan spectator:routes --spec=Api.v1.yml --prefix=api/v2 --middleware=api
+```
+
 ### `spectator:stubs`
 
 Generates skeleton test classes from a spec. Groups operations by tag (fallback: first path segment) and creates one class per group with one `test_` method per operation. Each method body calls `$this->markTestIncomplete(...)` so the generated file is immediately runnable.

--- a/src/Console/RoutesCommand.php
+++ b/src/Console/RoutesCommand.php
@@ -135,7 +135,11 @@ class RoutesCommand extends Command
     {
         if ($normalisedPrefix !== null) {
             $uri = ltrim($route->uri(), '/');
-            if ($normalisedPrefix !== '' && ! str_starts_with($uri, $normalisedPrefix)) {
+            if (
+                $normalisedPrefix !== ''
+                && $uri !== $normalisedPrefix
+                && ! str_starts_with($uri, $normalisedPrefix.'/')
+            ) {
                 return false;
             }
         }

--- a/src/Console/RoutesCommand.php
+++ b/src/Console/RoutesCommand.php
@@ -15,7 +15,9 @@ class RoutesCommand extends Command
 {
     protected $signature = 'spectator:routes
                             {--spec= : Spec file name (e.g. Api.v1.yml)}
-                            {--format=text : Output format: text or json}';
+                            {--format=text : Output format: text or json}
+                            {--prefix= : Only consider Laravel routes whose URI starts with this prefix (e.g. api/v2)}
+                            {--middleware= : Only consider Laravel routes that have this middleware (name or class)}';
 
     protected $description = 'Compare spec operations against registered Laravel routes.';
 
@@ -23,6 +25,8 @@ class RoutesCommand extends Command
     {
         $spec = $this->option('spec');
         $format = $this->option('format');
+        $prefix = $this->option('prefix');
+        $middleware = $this->option('middleware');
 
         if ($spec) {
             $factory->using($spec);
@@ -49,7 +53,7 @@ class RoutesCommand extends Command
         }
 
         // Build a normalised set of all Laravel route keys: "METHOD /path/{_}"
-        $laravelRoutes = $this->collectLaravelRoutes();
+        $laravelRoutes = $this->collectLaravelRoutes($prefix, $middleware);
 
         // Enumerate spec operations
         $specOps = [];
@@ -81,11 +85,16 @@ class RoutesCommand extends Command
         }
         sort($undocumented);
 
+        $filters = array_filter([
+            'prefix' => $prefix,
+            'middleware' => $middleware,
+        ], fn (?string $value) => $value !== null && $value !== '');
+
         if ($format === 'json') {
-            return $this->outputJson($specName, $specOps, $undocumented);
+            return $this->outputJson($specName, $specOps, $undocumented, $filters);
         }
 
-        return $this->outputText($specName, $specOps, $undocumented);
+        return $this->outputText($specName, $specOps, $undocumented, $filters);
     }
 
     /**
@@ -95,12 +104,17 @@ class RoutesCommand extends Command
      *
      * @return array<string, string>
      */
-    private function collectLaravelRoutes(): array
+    private function collectLaravelRoutes(?string $prefix, ?string $middleware): array
     {
         $routes = [];
+        $normalisedPrefix = $prefix !== null && $prefix !== '' ? trim($prefix, '/') : null;
 
         /** @var Route $route */
         foreach (RouteFacade::getRoutes()->getRoutes() as $route) {
+            if (! $this->routePassesFilters($route, $normalisedPrefix, $middleware)) {
+                continue;
+            }
+
             $uri = Str::start($route->uri(), '/');
 
             foreach ($route->methods() as $method) {
@@ -115,6 +129,29 @@ class RoutesCommand extends Command
         }
 
         return $routes;
+    }
+
+    private function routePassesFilters(Route $route, ?string $normalisedPrefix, ?string $middleware): bool
+    {
+        if ($normalisedPrefix !== null) {
+            $uri = ltrim($route->uri(), '/');
+            if ($normalisedPrefix !== '' && ! str_starts_with($uri, $normalisedPrefix)) {
+                return false;
+            }
+        }
+
+        if ($middleware !== null && $middleware !== '') {
+            $declared = $route->middleware();
+            // gatherMiddleware() expands group aliases (e.g. 'api') into resolved class names.
+            // Checking both lets users filter by either the alias they wrote or a fully-qualified class.
+            $gathered = method_exists($route, 'gatherMiddleware') ? $route->gatherMiddleware() : [];
+
+            if (! in_array($middleware, $declared, true) && ! in_array($middleware, $gathered, true)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -146,10 +183,19 @@ class RoutesCommand extends Command
     /**
      * @param  array<array{method: string, path: string, resolved: string, normalised: string, matched: bool}>  $specOps
      * @param  array<string>  $undocumented
+     * @param  array<string, string>  $filters
      */
-    private function outputText(string $specName, array $specOps, array $undocumented): int
+    private function outputText(string $specName, array $specOps, array $undocumented, array $filters): int
     {
         $this->info("Route comparison for {$specName}:");
+
+        if ($filters !== []) {
+            $this->line('Filters:');
+            foreach ($filters as $key => $value) {
+                $this->line("  {$key}={$value}");
+            }
+        }
+
         $this->newLine();
 
         $rows = [];
@@ -186,11 +232,13 @@ class RoutesCommand extends Command
     /**
      * @param  array<array{method: string, path: string, resolved: string, normalised: string, matched: bool}>  $specOps
      * @param  array<string>  $undocumented
+     * @param  array<string, string>  $filters
      */
-    private function outputJson(string $specName, array $specOps, array $undocumented): int
+    private function outputJson(string $specName, array $specOps, array $undocumented, array $filters): int
     {
         $payload = [
             'spec' => $specName,
+            'filters' => (object) $filters,
             'spec_operations' => array_map(fn ($op) => [
                 'method' => $op['method'],
                 'path' => $op['path'],

--- a/src/Console/RoutesCommand.php
+++ b/src/Console/RoutesCommand.php
@@ -52,8 +52,10 @@ class RoutesCommand extends Command
             return self::FAILURE;
         }
 
+        $normalisedPrefix = ($prefix !== null && trim($prefix, '/') !== '') ? trim($prefix, '/') : null;
+
         // Build a normalised set of all Laravel route keys: "METHOD /path/{_}"
-        $laravelRoutes = $this->collectLaravelRoutes($prefix, $middleware);
+        $laravelRoutes = $this->collectLaravelRoutes($normalisedPrefix, $middleware);
 
         // Enumerate spec operations
         $specOps = [];
@@ -86,7 +88,7 @@ class RoutesCommand extends Command
         sort($undocumented);
 
         $filters = array_filter([
-            'prefix' => $prefix,
+            'prefix' => $normalisedPrefix,
             'middleware' => $middleware,
         ], fn (?string $value) => $value !== null && $value !== '');
 
@@ -104,10 +106,9 @@ class RoutesCommand extends Command
      *
      * @return array<string, string>
      */
-    private function collectLaravelRoutes(?string $prefix, ?string $middleware): array
+    private function collectLaravelRoutes(?string $normalisedPrefix, ?string $middleware): array
     {
         $routes = [];
-        $normalisedPrefix = $prefix !== null && $prefix !== '' ? trim($prefix, '/') : null;
 
         /** @var Route $route */
         foreach (RouteFacade::getRoutes()->getRoutes() as $route) {
@@ -150,7 +151,23 @@ class RoutesCommand extends Command
             // Checking both lets users filter by either the alias they wrote or a fully-qualified class.
             $gathered = method_exists($route, 'gatherMiddleware') ? $route->gatherMiddleware() : [];
 
-            if (! in_array($middleware, $declared, true) && ! in_array($middleware, $gathered, true)) {
+            // Match by exact string or by base name before ':' to support parameterized
+            // middleware like 'throttle:60,1' when the user filters by 'throttle'.
+            $hasMiddleware = static function (array $list) use ($middleware): bool {
+                foreach ($list as $entry) {
+                    if ($entry === $middleware) {
+                        return true;
+                    }
+                    $colonPos = strpos($entry, ':');
+                    if ($colonPos !== false && substr($entry, 0, $colonPos) === $middleware) {
+                        return true;
+                    }
+                }
+
+                return false;
+            };
+
+            if (! $hasMiddleware($declared) && ! $hasMiddleware($gathered)) {
                 return false;
             }
         }

--- a/tests/Console/RoutesCommandTest.php
+++ b/tests/Console/RoutesCommandTest.php
@@ -249,4 +249,33 @@ class RoutesCommandTest extends TestCase
             ->assertExitCode(0)
             ->doesntExpectOutputToContain('Filters:');
     }
+
+    public function test_prefix_filter_does_not_match_partial_path_segment(): void
+    {
+        Route::get('/api/v2/things', fn () => [])->name('things.index');
+        Route::get('/api/v20/other', fn () => [])->name('other');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => 'api/v2',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->doesntExpectOutputToContain('/api/v20/other');
+    }
+
+    public function test_middleware_filter_matches_parameterized_middleware(): void
+    {
+        Route::get('/users', fn () => [])->middleware('throttle:60,1')->name('users.index');
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--middleware' => 'throttle',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"status": "matched"')
+            ->doesntExpectOutputToContain('"path": "/admin/things"');
+    }
 }

--- a/tests/Console/RoutesCommandTest.php
+++ b/tests/Console/RoutesCommandTest.php
@@ -3,6 +3,7 @@
 namespace Spectator\Tests\Console;
 
 use Illuminate\Support\Facades\Route;
+use Spectator\Middleware;
 use Spectator\Tests\TestCase;
 
 class RoutesCommandTest extends TestCase
@@ -91,5 +92,161 @@ class RoutesCommandTest extends TestCase
         $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml'])
             ->assertExitCode(0)
             ->expectsOutputToContain('matched,');
+    }
+
+    public function test_no_filter_keeps_existing_behavior(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml', '--format' => 'json'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"status": "matched"')
+            ->expectsOutputToContain('"path": "/admin/things"');
+    }
+
+    public function test_prefix_filter_excludes_routes_outside_prefix(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+        Route::get('/internal/health', fn () => [])->name('internal.health');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => 'users',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"status": "matched"')
+            ->expectsOutputToContain('"path": "/users"')
+            ->doesntExpectOutputToContain('"path": "/admin/things"')
+            ->doesntExpectOutputToContain('"path": "/internal/health"');
+    }
+
+    public function test_prefix_filter_with_no_matches_yields_empty_undocumented(): void
+    {
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+        Route::get('/internal/health', fn () => [])->name('internal.health');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => 'api/v2',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->doesntExpectOutputToContain('"path": "/admin/things"')
+            ->doesntExpectOutputToContain('"path": "/internal/health"');
+    }
+
+    public function test_prefix_filter_normalises_leading_and_trailing_slashes(): void
+    {
+        Route::get('/api/v2/things', fn () => [])->name('things.index');
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => '/api/v2/',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"path": "/api/v2/things"')
+            ->doesntExpectOutputToContain('"path": "/admin/things"');
+    }
+
+    public function test_middleware_filter_keeps_only_routes_with_that_middleware(): void
+    {
+        Route::middleware('api')->group(function () {
+            Route::get('/users', fn () => [])->name('users.index');
+        });
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--middleware' => 'api',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"path": "/users"')
+            ->expectsOutputToContain('"status": "matched"')
+            ->doesntExpectOutputToContain('"path": "/admin/things"');
+    }
+
+    public function test_middleware_filter_accepts_fully_qualified_class_name(): void
+    {
+        Route::get('/users', fn () => [])->middleware(Middleware::class)->name('users.index');
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--middleware' => Middleware::class,
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"path": "/users"')
+            ->expectsOutputToContain('"status": "matched"')
+            ->doesntExpectOutputToContain('"path": "/admin/things"');
+    }
+
+    public function test_middleware_filter_with_no_matches(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+        Route::get('/admin/things', fn () => [])->name('admin.things');
+        Route::get('/internal/health', fn () => [])->name('internal.health');
+
+        // With a filter that matches nothing, the Laravel side shrinks to empty.
+        // The spec operation for /users is still listed (spec ops aren't filtered),
+        // but it shows as unimplemented because the underlying route was filtered out.
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--middleware' => 'nonexistent',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"path": "/users"')
+            ->expectsOutputToContain('"status": "unimplemented"')
+            ->doesntExpectOutputToContain('"path": "/admin/things"')
+            ->doesntExpectOutputToContain('"path": "/internal/health"');
+    }
+
+    public function test_prefix_and_middleware_combined(): void
+    {
+        Route::middleware('api')->group(function () {
+            Route::get('/api/v2/things', fn () => [])->name('things.index');
+            Route::get('/other/api-but-wrong-prefix', fn () => [])->name('other');
+        });
+        Route::get('/api/v2/no-middleware', fn () => [])->name('plain');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => 'api/v2',
+            '--middleware' => 'api',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"path": "/api/v2/things"')
+            ->doesntExpectOutputToContain('"path": "/api/v2/no-middleware"')
+            ->doesntExpectOutputToContain('"path": "/other/api-but-wrong-prefix"');
+    }
+
+    public function test_filter_header_appears_in_text_output(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => 'users',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('Filters:')
+            ->expectsOutputToContain('prefix=users');
+    }
+
+    public function test_filter_header_omitted_when_no_filters(): void
+    {
+        Route::get('/users', fn () => [])->name('users.index');
+
+        $this->artisan('spectator:routes', ['--spec' => 'Test.v1.yml'])
+            ->assertExitCode(0)
+            ->doesntExpectOutputToContain('Filters:');
     }
 }


### PR DESCRIPTION
Add --prefix and --middleware filters to spectator:routes

Narrow the Laravel-routes side of the comparison so apps that only document a subset of their surface (e.g. /api/v2/*) don't drown in `undocumented` entries from internal admin/web/webhook routes.

- `--prefix=api/v2` keeps only routes whose URI starts with the given prefix; leading/trailing slashes are normalised.
- `--middleware=api` keeps only routes carrying the given middleware. Both group aliases and fully-qualified class names match (gatherMiddleware() is consulted to expand groups).
- Both are combinable (AND). When neither is set, behavior is unchanged.

Active filters surface in both text output (a Filters: block) and JSON output (a "filters" key) so the scoped result is unambiguous.

README updated with a "Scoping the comparison" subsection.