### PR TITLE
Fix(routes): show full resolved path in spectator:routes output

### DIFF
--- a/src/Console/RoutesCommand.php
+++ b/src/Console/RoutesCommand.php
@@ -225,7 +225,7 @@ class RoutesCommand extends Command
             $rows[] = [
                 $op['matched'] ? '<fg=green>matched</>' : '<fg=red>unimplemented</>',
                 $op['method'],
-                $op['path'],
+                $op['resolved'],
             ];
         }
 
@@ -262,7 +262,7 @@ class RoutesCommand extends Command
             'filters' => (object) $filters,
             'spec_operations' => array_map(fn ($op) => [
                 'method' => $op['method'],
-                'path' => $op['path'],
+                'path' => $op['resolved'],
                 'status' => $op['matched'] ? 'matched' : 'unimplemented',
             ], $specOps),
             'undocumented_routes' => array_values(array_map(function (string $key) {

--- a/tests/Console/RoutesCommandTest.php
+++ b/tests/Console/RoutesCommandTest.php
@@ -287,6 +287,24 @@ class RoutesCommandTest extends TestCase
     }
 
     #[Test]
+    public function test_displayed_path_includes_configured_path_prefix(): void
+    {
+        config(['spectator.path_prefix' => 'api/v4']);
+
+        Route::get('/api/v4/users', fn () => [])->name('users.index');
+
+        $this->artisan('spectator:routes', [
+            '--spec' => 'Test.v1.yml',
+            '--prefix' => 'api/v4',
+            '--format' => 'json',
+        ])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('"status": "matched"')
+            ->expectsOutputToContain('"path": "/api/v4/users"')
+            ->doesntExpectOutputToContain('"path": "/users"');
+    }
+
+    #[Test]
     public function test_middleware_filter_matches_parameterized_middleware(): void
     {
         Route::get('/users', fn () => [])->middleware('throttle:60,1')->name('users.index');


### PR DESCRIPTION
## Summary
When running `spectator:routes` with a configured `path_prefix` (or `--prefix` filter), the table displayed the raw spec path (`/files`) instead of the actual path used for matching against Laravel routes (`/api/v4/files`). This was inconsistent with the undocumented rows, which already showed the full URI, and made the output confusing when a prefix was in play.

The fix swaps the displayed value from the raw spec path to the resolved path in both the text table and JSON output.

## Before
<img width="537" height="167" alt="CleanShot 2026-05-01 at 15 03 57" src="https://github.com/user-attachments/assets/931a380c-7d86-470f-95d2-1f7e65ffdcfb" />

## After
<img width="622" height="169" alt="CleanShot 2026-05-01 at 15 04 30" src="https://github.com/user-attachments/assets/308e5d04-0769-4653-af43-3fee569906bf" />
