### PR TITLE
fix: return stdClass for empty x-www-form-urlencoded request body

### DIFF
--- a/src/Validation/RequestValidator.php
+++ b/src/Validation/RequestValidator.php
@@ -200,6 +200,10 @@ class RequestValidator extends AbstractValidator
             }
         });
 
+        if ($body === []) {
+            return new stdClass;
+        }
+
         return $this->toObject($body);
     }
 

--- a/tests/Fixtures/EmptyFormRequestBody.yml
+++ b/tests/Fixtures/EmptyFormRequestBody.yml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: EmptyFormRequestBody
+  version: '1.0'
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /shares:
+    post:
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - file_id
+              properties:
+                file_id:
+                  type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -232,6 +232,20 @@ class RequestValidatorTest extends TestCase
             ->assertValidRequest();
     }
 
+    #[Test]
+    public function empty_form_request_body_does_not_crash(): void
+    {
+        Spectator::using('EmptyFormRequestBody.yml');
+
+        Route::post('/shares', function () {
+            return [];
+        })->middleware([Middleware::class]);
+
+        $this->post('/shares', [], ['Content-Type' => 'application/x-www-form-urlencoded'])
+            ->assertInvalidRequest()
+            ->assertErrorsContain(['The required properties (file_id) are missing']);
+    }
+
     #[DataProvider('nullableProvider')]
     #[Test]
     public function handle_nullables($version, $state, $isValid): void


### PR DESCRIPTION
## Problem

When a request with `Content-Type: application/x-www-form-urlencoded` and an empty body is validated, Spectator throws a `TypeError`:

```
Spectator\Validation\RequestValidator::parseBodySchema(): Return value must be of type stdClass, array returned
```

The root cause is in `parseBodySchema()`. It calls `toObject($body)` where `$body` is `[]`. `toObject` uses `Arr::isAssoc()` to decide whether to cast to `stdClass` — but `Arr::isAssoc([])` returns `false`, so an empty array is treated as sequential and returned as-is, violating the declared `stdClass` return type.

Because this is a `TypeError` rather than a `RequestValidationException`, it escapes the narrow catch in `Middleware` and surfaces as a `500` response instead of a validation error.

This only affects non-JSON content types (the JSON branch handles empty bodies separately). It is triggered by any `application/x-www-form-urlencoded` or `multipart/form-data` request with an empty payload.

## Fix

Return `new stdClass` early when `$body === []`, before calling `toObject()`.

## Test

Added `empty_form_request_body_does_not_crash` to `RequestValidatorTest`, which posts an empty form-encoded body to a route whose schema requires a `file_id` field, and asserts Spectator produces a clean `assertInvalidRequest()` with a missing-property error rather than crashing.